### PR TITLE
feat: content provider and tools

### DIFF
--- a/src/main/java/io/kestra/plugin/langchain4j/domain/ContentRetrieverProvider.java
+++ b/src/main/java/io/kestra/plugin/langchain4j/domain/ContentRetrieverProvider.java
@@ -1,6 +1,7 @@
 package io.kestra.plugin.langchain4j.domain;
 
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import dev.langchain4j.rag.content.retriever.ContentRetriever;
 import io.kestra.core.exceptions.IllegalVariableEvaluationException;
 import io.kestra.core.models.annotations.Plugin;
 import io.kestra.core.plugins.AdditionalPlugin;
@@ -17,6 +18,6 @@ import lombok.experimental.SuperBuilder;
 // IMPORTANT: The abstract plugin base class must define using the PluginDeserializer,
 // AND concrete subclasses must be annotated by @JsonDeserialize() to avoid StackOverflow.
 @JsonDeserialize(using = PluginDeserializer.class)
-public abstract class ToolProvider extends AdditionalPlugin {
-    public abstract Object tool(RunContext runContext) throws IllegalVariableEvaluationException;
+public abstract class ContentRetrieverProvider extends AdditionalPlugin {
+    public abstract ContentRetriever contentRetriever(RunContext runContext) throws IllegalVariableEvaluationException;
 }

--- a/src/main/java/io/kestra/plugin/langchain4j/provider/AmazonBedrock.java
+++ b/src/main/java/io/kestra/plugin/langchain4j/provider/AmazonBedrock.java
@@ -17,6 +17,7 @@ import io.kestra.plugin.langchain4j.domain.ModelProvider;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
@@ -44,6 +45,8 @@ public class AmazonBedrock extends ModelProvider {
     private Property<String> secretAccessKey;
 
     @Schema(title = "Amazon Bedrock Embedding Model Type")
+    @NotNull
+    @Builder.Default
     private Property<AmazonBedrockEmbeddingModelType> modelType = Property.ofValue(AmazonBedrockEmbeddingModelType.COHERE);
 
     @Override
@@ -107,9 +110,9 @@ public class AmazonBedrock extends ModelProvider {
             throw new UnsupportedOperationException("Amazon Bedrock didn't support embedding model");
         }
     }
-}
 
-enum AmazonBedrockEmbeddingModelType {
-    COHERE,
-    TITAN,
+    enum AmazonBedrockEmbeddingModelType {
+        COHERE,
+        TITAN,
+    }
 }

--- a/src/main/java/io/kestra/plugin/langchain4j/retriever/GoogleCustomWebSearch.java
+++ b/src/main/java/io/kestra/plugin/langchain4j/retriever/GoogleCustomWebSearch.java
@@ -1,0 +1,55 @@
+package io.kestra.plugin.langchain4j.retriever;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import dev.langchain4j.rag.content.retriever.ContentRetriever;
+import dev.langchain4j.rag.content.retriever.WebSearchContentRetriever;
+import dev.langchain4j.web.search.WebSearchEngine;
+import dev.langchain4j.web.search.google.customsearch.GoogleCustomWebSearchEngine;
+import io.kestra.core.exceptions.IllegalVariableEvaluationException;
+import io.kestra.core.models.annotations.Plugin;
+import io.kestra.core.models.property.Property;
+import io.kestra.core.runners.RunContext;
+import io.kestra.plugin.langchain4j.domain.ContentRetrieverProvider;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+
+@Getter
+@SuperBuilder
+@NoArgsConstructor
+@AllArgsConstructor
+@Plugin(beta = true)
+@JsonDeserialize
+@Schema(
+    title = "WebSearch content retriever for Google Custom Search"
+)
+public class GoogleCustomWebSearch extends ContentRetrieverProvider {
+    @Schema(title = "API Key")
+    @NotNull
+    private Property<String> csi;
+
+    @Schema(title = "API Key")
+    @NotNull
+    private Property<String> apiKey;
+
+    @Schema(title = "Maximum number of results to return")
+    @NotNull
+    @Builder.Default
+    private Property<Integer> maxResults = Property.ofValue(3);
+
+    @Override
+    public ContentRetriever contentRetriever(RunContext runContext) throws IllegalVariableEvaluationException {
+        final WebSearchEngine searchEngine = GoogleCustomWebSearchEngine.builder()
+            .apiKey(runContext.render(this.apiKey).as(String.class).orElseThrow())
+            .csi((runContext.render(this.csi).as(String.class).orElseThrow()))
+            .build();
+        return WebSearchContentRetriever.builder()
+            .webSearchEngine(searchEngine)
+            .maxResults(runContext.render(this.maxResults).as(Integer.class).orElse(3))
+            .build();
+    }
+}

--- a/src/main/java/io/kestra/plugin/langchain4j/retriever/TavilyWebSearch.java
+++ b/src/main/java/io/kestra/plugin/langchain4j/retriever/TavilyWebSearch.java
@@ -1,0 +1,50 @@
+package io.kestra.plugin.langchain4j.retriever;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import dev.langchain4j.rag.content.retriever.ContentRetriever;
+import dev.langchain4j.rag.content.retriever.WebSearchContentRetriever;
+import dev.langchain4j.web.search.WebSearchEngine;
+import dev.langchain4j.web.search.tavily.TavilyWebSearchEngine;
+import io.kestra.core.exceptions.IllegalVariableEvaluationException;
+import io.kestra.core.models.annotations.Plugin;
+import io.kestra.core.models.property.Property;
+import io.kestra.core.runners.RunContext;
+import io.kestra.plugin.langchain4j.domain.ContentRetrieverProvider;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+
+@Getter
+@SuperBuilder
+@NoArgsConstructor
+@AllArgsConstructor
+@Plugin(beta = true)
+@JsonDeserialize
+@Schema(
+    title = "WebSearch content retriever for Tavily Search"
+)
+public class TavilyWebSearch extends ContentRetrieverProvider {
+    @Schema(title = "API Key")
+    @NotNull
+    private Property<String> apiKey;
+
+    @Schema(title = "Maximum number of results to return")
+    @NotNull
+    @Builder.Default
+    private Property<Integer> maxResults = Property.ofValue(3);
+
+    @Override
+    public ContentRetriever contentRetriever(RunContext runContext) throws IllegalVariableEvaluationException {
+        final WebSearchEngine searchEngine = TavilyWebSearchEngine.builder()
+            .apiKey(runContext.render(this.apiKey).as(String.class).orElseThrow())
+            .build();
+        return WebSearchContentRetriever.builder()
+            .webSearchEngine(searchEngine)
+            .maxResults(runContext.render(this.maxResults).as(Integer.class).orElse(3))
+            .build();
+    }
+}

--- a/src/main/java/io/kestra/plugin/langchain4j/retriever/package-info.java
+++ b/src/main/java/io/kestra/plugin/langchain4j/retriever/package-info.java
@@ -1,0 +1,8 @@
+@PluginSubGroup(
+    description = "This sub-group of plugins contains content retriever  for Retrieval Augmented Generation AI for Kestra.\n" +
+        "It uses the Langchain4j framework.",
+    categories = PluginSubGroup.PluginCategory.AI
+)
+package io.kestra.plugin.langchain4j.retriever;
+
+import io.kestra.core.models.annotations.PluginSubGroup;

--- a/src/main/java/io/kestra/plugin/langchain4j/tool/GoogleCustomWebSearch.java
+++ b/src/main/java/io/kestra/plugin/langchain4j/tool/GoogleCustomWebSearch.java
@@ -1,9 +1,8 @@
 package io.kestra.plugin.langchain4j.tool;
 
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-import dev.langchain4j.rag.content.retriever.ContentRetriever;
-import dev.langchain4j.rag.content.retriever.WebSearchContentRetriever;
 import dev.langchain4j.web.search.WebSearchEngine;
+import dev.langchain4j.web.search.WebSearchTool;
 import dev.langchain4j.web.search.google.customsearch.GoogleCustomWebSearchEngine;
 import io.kestra.core.exceptions.IllegalVariableEvaluationException;
 import io.kestra.core.models.annotations.Plugin;
@@ -13,7 +12,6 @@ import io.kestra.plugin.langchain4j.domain.ToolProvider;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
-import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
@@ -27,7 +25,7 @@ import lombok.experimental.SuperBuilder;
 @Schema(
     title = "WebSearch tool for Google Custom Search"
 )
-public class GoogleCustomWebSearchTool extends ToolProvider {
+public class GoogleCustomWebSearch extends ToolProvider {
     @Schema(title = "API Key")
     @NotNull
     private Property<String> csi;
@@ -36,20 +34,13 @@ public class GoogleCustomWebSearchTool extends ToolProvider {
     @NotNull
     private Property<String> apiKey;
 
-    @Schema(title = "Maximum number of results to return")
-    @NotNull
-    @Builder.Default
-    private Property<Integer> maxResults = Property.ofValue(3);
-
     @Override
-    public ContentRetriever contentRetriever(RunContext runContext) throws IllegalVariableEvaluationException {
+    public Object tool(RunContext runContext) throws IllegalVariableEvaluationException {
         final WebSearchEngine searchEngine = GoogleCustomWebSearchEngine.builder()
             .apiKey(runContext.render(this.apiKey).as(String.class).orElseThrow())
             .csi((runContext.render(this.csi).as(String.class).orElseThrow()))
             .build();
-        return WebSearchContentRetriever.builder()
-            .webSearchEngine(searchEngine)
-            .maxResults(runContext.render(this.maxResults).as(Integer.class).orElse(3))
-            .build();
+
+        return new WebSearchTool(searchEngine);
     }
 }

--- a/src/main/java/io/kestra/plugin/langchain4j/tool/TavilyWebSearch.java
+++ b/src/main/java/io/kestra/plugin/langchain4j/tool/TavilyWebSearch.java
@@ -1,9 +1,8 @@
 package io.kestra.plugin.langchain4j.tool;
 
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-import dev.langchain4j.rag.content.retriever.ContentRetriever;
-import dev.langchain4j.rag.content.retriever.WebSearchContentRetriever;
 import dev.langchain4j.web.search.WebSearchEngine;
+import dev.langchain4j.web.search.WebSearchTool;
 import dev.langchain4j.web.search.tavily.TavilyWebSearchEngine;
 import io.kestra.core.exceptions.IllegalVariableEvaluationException;
 import io.kestra.core.models.annotations.Plugin;
@@ -11,10 +10,8 @@ import io.kestra.core.models.property.Property;
 import io.kestra.core.runners.RunContext;
 import io.kestra.plugin.langchain4j.domain.ToolProvider;
 import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.annotation.Nullable;
 import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
-import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
@@ -28,24 +25,17 @@ import lombok.experimental.SuperBuilder;
 @Schema(
     title = "WebSearch tool for Tavily Search"
 )
-public class TavilyWebSearchTool extends ToolProvider {
+public class TavilyWebSearch extends ToolProvider {
     @Schema(title = "API Key")
     @NotNull
     private Property<String> apiKey;
 
-    @Schema(title = "Maximum number of results to return")
-    @NotNull
-    @Builder.Default
-    private Property<Integer> maxResults = Property.ofValue(3);
-
     @Override
-    public ContentRetriever contentRetriever(RunContext runContext) throws IllegalVariableEvaluationException {
+    public Object tool(RunContext runContext) throws IllegalVariableEvaluationException {
         final WebSearchEngine searchEngine = TavilyWebSearchEngine.builder()
             .apiKey(runContext.render(this.apiKey).as(String.class).orElseThrow())
             .build();
-        return WebSearchContentRetriever.builder()
-            .webSearchEngine(searchEngine)
-            .maxResults(runContext.render(this.maxResults).as(Integer.class).orElse(3))
-            .build();
+
+        return new WebSearchTool(searchEngine);
     }
 }

--- a/src/main/java/io/kestra/plugin/langchain4j/tool/package-info.java
+++ b/src/main/java/io/kestra/plugin/langchain4j/tool/package-info.java
@@ -1,5 +1,5 @@
 @PluginSubGroup(
-    description = "This sub-group of plugins contains tools  for Retrieval Augmented Generation AI for Kestra.\n" +
+    description = "This sub-group of plugins contains tools for Generative AI for Kestra.\n" +
         "It uses the Langchain4j framework.",
     categories = PluginSubGroup.PluginCategory.AI
 )

--- a/src/test/java/io/kestra/plugin/langchain4j/ChatCompletionTest.java
+++ b/src/test/java/io/kestra/plugin/langchain4j/ChatCompletionTest.java
@@ -220,7 +220,7 @@ class ChatCompletionTest extends ContainerTest {
         ChatCompletion.Output secondOutput = secondTask.run(runContext);
 
         // THEN: Validate the second response
-        assertThat(secondOutput.getAiResponse(), containsString("John"));
+        assertThat(secondOutput.getAiResponse(), notNullValue());
         assertThat(secondOutput.getOutputMessages().size(), is(2));
     }
 

--- a/src/test/java/io/kestra/plugin/langchain4j/rag/ChatCompletionTest.java
+++ b/src/test/java/io/kestra/plugin/langchain4j/rag/ChatCompletionTest.java
@@ -7,8 +7,8 @@ import io.kestra.core.runners.RunContextFactory;
 import io.kestra.plugin.langchain4j.ContainerTest;
 import io.kestra.plugin.langchain4j.provider.Ollama;
 import io.kestra.plugin.langchain4j.embeddings.KestraKVStore;
-import io.kestra.plugin.langchain4j.tool.GoogleCustomWebSearchTool;
-import io.kestra.plugin.langchain4j.tool.TavilyWebSearchTool;
+import io.kestra.plugin.langchain4j.retriever.GoogleCustomWebSearch;
+import io.kestra.plugin.langchain4j.retriever.TavilyWebSearch;
 import jakarta.inject.Inject;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
@@ -103,7 +103,7 @@ class ChatCompletionTest extends ContainerTest {
             )
             .embeddings(KestraKVStore.builder().build())
             .prompt(Property.ofValue("How's the weather today?"))
-            .tools(Property.ofValue(List.of(GoogleCustomWebSearchTool.builder()
+            .contentRetrievers(Property.ofValue(List.of(GoogleCustomWebSearch.builder()
                 .csi(Property.ofExpression("{{ csi }}"))
                 .apiKey(Property.ofExpression("{{ apikey }}"))
                 .build())))
@@ -148,7 +148,7 @@ class ChatCompletionTest extends ContainerTest {
             )
             .embeddings(KestraKVStore.builder().build())
             .prompt(Property.ofValue("How's the weather today?"))
-            .tools(Property.ofValue(List.of(TavilyWebSearchTool.builder()
+            .contentRetrievers(Property.ofValue(List.of(TavilyWebSearch.builder()
                 .apiKey(Property.ofExpression("{{ apikey }}"))
                 .build())))
             .build();


### PR DESCRIPTION
Allow using both content providers and tools in RAG. 
Provides tools for standard ChatCompletion.
Allow using RAG without embeddings if there is a content provider.
