### PR TITLE
fix(provider-openai): default creds handling

### DIFF
--- a/src/main/java/io/kestra/plugin/ai/provider/AzureOpenAI.java
+++ b/src/main/java/io/kestra/plugin/ai/provider/AzureOpenAI.java
@@ -175,21 +175,19 @@ public class AzureOpenAI extends ModelProvider {
                     .endpoint(runContext.render(this.getEndpoint()).as(String.class).orElseThrow())
                     .serviceVersion(runContext.render(this.getServiceVersion()).as(String.class).orElse(null))
                     .build();
-        } else if (tenantId != null && clientId != null && clientSecret != null) {
+        } else {
             return AzureOpenAiEmbeddingModel.builder()
                     .tokenCredential(credentials(runContext, tenantId, clientId, clientSecret))
                     .deploymentName(runContext.render(this.getModelName()).as(String.class).orElseThrow())
                     .endpoint(runContext.render(this.getEndpoint()).as(String.class).orElseThrow())
                     .serviceVersion(runContext.render(this.getServiceVersion()).as(String.class).orElse(null))
                     .build();
-        } else {
-            throw new IllegalArgumentException("You need to set an API Key or a tenantId, clientId and clientSecret");
         }
     }
 
     private TokenCredential credentials(RunContext runContext, String tenantId, String clientId, String clientSecret) {
 
-        if (StringUtils.isNotBlank(clientSecret)) {
+        if (StringUtils.isNotBlank(tenantId) && StringUtils.isNotBlank(clientId) && StringUtils.isNotBlank(clientSecret)) {
             runContext.logger().info("Authentication is using Client Secret Credentials");
             return new ClientSecretCredentialBuilder()
                     .clientId(clientId)


### PR DESCRIPTION
Since for `DefaultAzureCredentialBuilder` also, tenantId is also not required, so no need to check for null.

> Sets the tenant id of the user to authenticate through the {'@'link DefaultAzureCredential}. If unset, the value
>  in the AZURE_TENANT_ID environment variable will be used. If neither is set, the default is null
>  and will authenticate users to their default tenant.

https://kestra-io.slack.com/archives/C07KA8R1K0F/p1756920900243799
