### PR TITLE
feat(memory): introduce PostgreSQL as a chat memory

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -152,6 +152,9 @@ dependencies {
     testImplementation 'org.testcontainers:chromadb:1.21.3'
     testImplementation 'org.testcontainers:milvus:1.21.3'
     testImplementation 'org.testcontainers:mongodb:1.21.3'
+
+    // Memories
+    testImplementation "org.testcontainers:postgresql:1.21.3"
 }
 
 /**********************************************************************************************************************\

--- a/src/main/java/io/kestra/plugin/ai/memory/PostgreSQL.java
+++ b/src/main/java/io/kestra/plugin/ai/memory/PostgreSQL.java
@@ -1,0 +1,218 @@
+package io.kestra.plugin.ai.memory;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import dev.langchain4j.data.message.ChatMessageDeserializer;
+import dev.langchain4j.data.message.ChatMessageSerializer;
+import dev.langchain4j.memory.ChatMemory;
+import dev.langchain4j.memory.chat.MessageWindowChatMemory;
+import io.kestra.core.exceptions.IllegalVariableEvaluationException;
+import io.kestra.core.models.annotations.Example;
+import io.kestra.core.models.annotations.Plugin;
+import io.kestra.core.models.property.Property;
+import io.kestra.core.runners.RunContext;
+import io.kestra.plugin.ai.domain.MemoryProvider;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+
+import java.io.IOException;
+import java.sql.*;
+import java.time.Duration;
+import java.time.Instant;
+
+@Getter
+@SuperBuilder
+@NoArgsConstructor
+@JsonDeserialize
+@Schema(
+    title = "Chat Memory backed by PostgreSQL",
+    description = """
+        Persist chat memory in a PostgreSQL table using the memory ID as the primary key.
+        The entry will expire after the provided TTL if configured.
+        Ensure your PostgreSQL database is reachable and configured via plugin properties.
+        """
+)
+@Plugin(
+    examples = {
+        @Example(
+            title = "Use PostgreSQL-based chat memory for a conversation",
+            code = """
+                id: chat_with_memory
+                namespace: company.ai
+
+                tasks:
+                  - id: first
+                    type: io.kestra.plugin.ai.rag.ChatCompletion
+                    chatProvider:
+                      type: io.kestra.plugin.ai.provider.GoogleGemini
+                      modelName: gemini-2.5-flash
+                      apiKey: "{{ kv('GEMINI_API_KEY') }}"
+                    memory:
+                      type: io.kestra.plugin.ai.memory.PostgreSQL
+                      host: localhost
+                      port: 5432
+                      database: ai_memory
+                      user: postgres
+                      password: secret
+                      tableName: my_custom_memory_table
+                    systemMessage: You are a helpful assistant, answer concisely
+                    prompt: "{{inputs.first}}"
+                """
+        )
+    }
+)
+public class PostgreSQL extends MemoryProvider {
+
+    @JsonIgnore
+    private transient ChatMemory chatMemory;
+
+    @NotNull
+    @Schema(title = "PostgreSQL host", description = "The hostname of your PostgreSQL server")
+    private Property<String> host;
+
+    @Schema(title = "PostgreSQL port", description = "The port of your PostgreSQL server")
+    private Property<Integer> port = Property.ofValue(5432);
+
+    @NotNull
+    @Schema(title = "Database name", description = "The name of the PostgreSQL database")
+    private Property<String> database;
+
+    @NotNull
+    @Schema(title = "Database user", description = "The username to connect to PostgreSQL")
+    private Property<String> user;
+
+    @NotNull
+    @Schema(title = "Database password", description = "The password to connect to PostgreSQL")
+    private Property<String> password;
+
+    @Schema(
+        title = "Table name",
+        description = "The name of the table used to store chat memory. Defaults to 'chat_memory'."
+    )
+    @Builder.Default
+    private Property<String> tableName = Property.ofValue("chat_memory");
+
+    @Override
+    public ChatMemory chatMemory(RunContext runContext) throws IllegalVariableEvaluationException, IOException {
+        var config = resolvedConfig(runContext);
+
+        this.chatMemory = MessageWindowChatMemory.withMaxMessages(
+            runContext.render(this.getMessages()).as(Integer.class).orElseThrow()
+        );
+
+        var key = runContext.render(this.getMemoryId()).as(String.class).orElseThrow();
+
+        try (Connection conn = connection(config)) {
+            ensureTableExists(conn, config.tableName());
+
+            try (PreparedStatement stmt = conn.prepareStatement(
+                "SELECT memory_json, expires_at FROM " + config.tableName() + " WHERE memory_id = ?"
+            )) {
+                stmt.setString(1, key);
+                ResultSet rs = stmt.executeQuery();
+
+                if (rs.next()) {
+                    Timestamp expiresAt = rs.getTimestamp("expires_at");
+                    if (expiresAt == null || expiresAt.toInstant().isAfter(Instant.now())) {
+                        if (config.drop() == Drop.BEFORE_TASKRUN) {
+                            deleteMemory(conn, key, config.tableName());
+                        } else {
+                            String json = rs.getString("memory_json");
+                            var messages = ChatMessageDeserializer.messagesFromJson(json);
+                            messages.forEach(chatMemory::add);
+                        }
+                    } else {
+                        deleteMemory(conn, key, config.tableName());
+                    }
+                }
+            }
+        } catch (SQLException e) {
+            throw new IOException("Failed to load chat memory from PostgreSQL", e);
+        }
+
+        return chatMemory;
+    }
+
+    @Override
+    public void close(RunContext runContext) throws IllegalVariableEvaluationException, IOException {
+        if (chatMemory == null) return;
+
+        var config = resolvedConfig(runContext);
+        var key = runContext.render(this.getMemoryId()).as(String.class).orElseThrow();
+        var ttl = runContext.render(this.getTtl()).as(Duration.class).orElse(Duration.ofMinutes(10));
+
+        try (Connection conn = connection(config)) {
+            ensureTableExists(conn, config.tableName());
+
+            if (config.drop() == Drop.AFTER_TASKRUN) {
+                deleteMemory(conn, key, config.tableName());
+            } else {
+                String memoryJson = ChatMessageSerializer.messagesToJson(chatMemory.messages());
+                Instant expiresAt = Instant.now().plus(ttl);
+
+                try (PreparedStatement upsert = conn.prepareStatement(
+                    "INSERT INTO " + config.tableName() + " (memory_id, memory_json, expires_at) " +
+                        "VALUES (?, ?, ?) " +
+                        "ON CONFLICT (memory_id) " +
+                        "DO UPDATE SET memory_json = EXCLUDED.memory_json, expires_at = EXCLUDED.expires_at"
+                )) {
+                    upsert.setString(1, key);
+                    upsert.setString(2, memoryJson);
+                    upsert.setTimestamp(3, Timestamp.from(expiresAt));
+                    upsert.executeUpdate();
+                }
+            }
+        } catch (SQLException e) {
+            throw new IOException("Failed to save chat memory to PostgreSQL", e);
+        }
+    }
+
+    private record ResolvedConfig(String host, int port, String database, String user, String password,
+                                  String tableName, Drop drop) {
+    }
+
+    private ResolvedConfig resolvedConfig(RunContext runContext) throws IllegalVariableEvaluationException {
+        var rHost = runContext.render(this.getHost()).as(String.class).orElseThrow();
+        var rPort = runContext.render(this.getPort()).as(Integer.class).orElse(5432);
+        var rDb = runContext.render(this.getDatabase()).as(String.class).orElseThrow();
+        var rUser = runContext.render(this.getUser()).as(String.class).orElseThrow();
+        var rPass = runContext.render(this.getPassword()).as(String.class).orElseThrow();
+        var rDrop = runContext.render(this.getDrop()).as(Drop.class).orElse(Drop.NEVER);
+        var rTable = runContext.render(this.getTableName()).as(String.class).orElse("chat_memory");
+
+        return new ResolvedConfig(rHost, rPort, rDb, rUser, rPass, rTable, rDrop);
+    }
+
+    private Connection connection(ResolvedConfig cfg) throws SQLException {
+        return DriverManager.getConnection(
+            String.format("jdbc:postgresql://%s:%d/%s", cfg.host(), cfg.port(), cfg.database()),
+            cfg.user(),
+            cfg.password()
+        );
+    }
+
+    private void ensureTableExists(Connection conn, String tableName) throws SQLException {
+        try (Statement stmt = conn.createStatement()) {
+            stmt.execute("""
+                    CREATE TABLE IF NOT EXISTS %s (
+                        memory_id VARCHAR(255) PRIMARY KEY,
+                        memory_json TEXT NOT NULL,
+                        expires_at TIMESTAMP NULL
+                    )
+                """.formatted(tableName));
+        }
+    }
+
+    private void deleteMemory(Connection conn, String key, String tableName) throws SQLException {
+        try (PreparedStatement stmt = conn.prepareStatement(
+            "DELETE FROM " + tableName + " WHERE memory_id = ?"
+        )) {
+            stmt.setString(1, key);
+            stmt.executeUpdate();
+        }
+    }
+}

--- a/src/test/java/io/kestra/plugin/ai/memory/PostgreSQLTest.java
+++ b/src/test/java/io/kestra/plugin/ai/memory/PostgreSQLTest.java
@@ -1,0 +1,182 @@
+package io.kestra.plugin.ai.memory;
+
+import io.kestra.core.context.TestRunContextFactory;
+import io.kestra.core.junit.annotations.KestraTest;
+import io.kestra.core.models.property.Property;
+import io.kestra.core.runners.RunContext;
+import io.kestra.core.utils.IdUtils;
+import io.kestra.plugin.ai.ContainerTest;
+import io.kestra.plugin.ai.domain.ChatConfiguration;
+import io.kestra.plugin.ai.embeddings.KestraKVStore;
+import io.kestra.plugin.ai.provider.Ollama;
+import io.kestra.plugin.ai.rag.ChatCompletion;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.utility.DockerImageName;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.ResultSet;
+import java.sql.Statement;
+import java.time.Duration;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@KestraTest
+class PostgreSQLTest extends ContainerTest {
+
+    @Inject
+    private TestRunContextFactory runContextFactory;
+
+    static PostgreSQLContainer<?> postgres;
+
+    @BeforeAll
+    static void startPostgres() {
+        postgres = new PostgreSQLContainer<>(DockerImageName.parse("postgres:16"))
+            .withDatabaseName("ai_memory")
+            .withUsername("postgres")
+            .withPassword("secret");
+        postgres.start();
+    }
+
+    @Test
+    void testMemoryWithDefaultTable() throws Exception {
+        String pgHost = postgres.getHost();
+        Integer pgPort = postgres.getMappedPort(5432);
+        String database = postgres.getDatabaseName();
+        String user = postgres.getUsername();
+        String password = postgres.getPassword();
+
+        RunContext runContext = runContextFactory.of("namespace", Map.of(
+            "modelName", "tinydolphin",
+            "endpoint", ollamaEndpoint,
+            "labels", Map.of("system", Map.of("correlationId", IdUtils.create()))
+        ));
+
+        // First prompt : store chat memory in default table (chat_memory)
+        var rag = ChatCompletion.builder()
+            .chatProvider(
+                Ollama.builder()
+                    .type(Ollama.class.getName())
+                    .modelName(Property.ofExpression("{{ modelName }}"))
+                    .endpoint(Property.ofExpression("{{ endpoint }}"))
+                    .build()
+            )
+            .embeddings(KestraKVStore.builder().build())
+            .memory(PostgreSQL.builder()
+                .host(Property.ofValue(pgHost))
+                .port(Property.ofValue(pgPort))
+                .database(Property.ofValue(database))
+                .user(Property.ofValue(user))
+                .password(Property.ofValue(password))
+                .ttl(Property.ofValue(Duration.ofMinutes(5)))
+                .memoryId(Property.ofValue("test-memory"))
+                .build())
+            .prompt(Property.ofValue("Hello, my name is Alice"))
+            .chatConfiguration(ChatConfiguration.builder()
+                .temperature(Property.ofValue(0.1))
+                .seed(Property.ofValue(123456789))
+                .build())
+            .build();
+
+        var ragOutput = rag.run(runContext);
+        assertThat(ragOutput.getTextOutput()).isNotNull();
+
+        // Second prompt : retrieve persisted chat memory
+        rag = ChatCompletion.builder()
+            .chatProvider(
+                Ollama.builder()
+                    .type(Ollama.class.getName())
+                    .modelName(Property.ofExpression("{{ modelName }}"))
+                    .endpoint(Property.ofExpression("{{ endpoint }}"))
+                    .build()
+            )
+            .embeddings(KestraKVStore.builder().build())
+            .memory(PostgreSQL.builder()
+                .host(Property.ofValue(pgHost))
+                .port(Property.ofValue(pgPort))
+                .database(Property.ofValue(database))
+                .user(Property.ofValue(user))
+                .password(Property.ofValue(password))
+                .memoryId(Property.ofValue("test-memory"))
+                .build())
+            .prompt(Property.ofValue("What's my name?"))
+            .chatConfiguration(ChatConfiguration.builder()
+                .temperature(Property.ofValue(0.1))
+                .seed(Property.ofValue(123456789))
+                .build())
+            .build();
+
+        ragOutput = rag.run(runContext);
+
+        assertThat(ragOutput.getTextOutput()).isNotNull();
+        assertThat(ragOutput.getTextOutput().toLowerCase()).contains("alice");
+
+        // Validate data persisted in default table
+        try (Connection conn = DriverManager.getConnection(
+            String.format("jdbc:postgresql://%s:%d/%s", pgHost, pgPort, database), user, password);
+             Statement stmt = conn.createStatement();
+             ResultSet rs = stmt.executeQuery("SELECT COUNT(*) FROM chat_memory")) {
+            assertThat(rs.next()).isTrue();
+            assertThat(rs.getInt(1)).isGreaterThan(0);
+        }
+    }
+
+    @Test
+    void testMemoryWithCustomTable() throws Exception {
+        String pgHost = postgres.getHost();
+        Integer pgPort = postgres.getMappedPort(5432);
+        String database = postgres.getDatabaseName();
+        String user = postgres.getUsername();
+        String password = postgres.getPassword();
+        String customTable = "custom_chat_memory";
+
+        RunContext runContext = runContextFactory.of("namespace", Map.of(
+            "modelName", "tinydolphin",
+            "endpoint", ollamaEndpoint,
+            "labels", Map.of("system", Map.of("correlationId", IdUtils.create()))
+        ));
+
+        // First prompt : store chat memory in a custom table
+        var rag = ChatCompletion.builder()
+            .chatProvider(
+                Ollama.builder()
+                    .type(Ollama.class.getName())
+                    .modelName(Property.ofExpression("{{ modelName }}"))
+                    .endpoint(Property.ofExpression("{{ endpoint }}"))
+                    .build()
+            )
+            .embeddings(KestraKVStore.builder().build())
+            .memory(PostgreSQL.builder()
+                .host(Property.ofValue(pgHost))
+                .port(Property.ofValue(pgPort))
+                .database(Property.ofValue(database))
+                .user(Property.ofValue(user))
+                .password(Property.ofValue(password))
+                .tableName(Property.ofValue(customTable))
+                .ttl(Property.ofValue(Duration.ofMinutes(5)))
+                .memoryId(Property.ofValue("custom-memory"))
+                .build())
+            .prompt(Property.ofValue("Hello, my name is Bob"))
+            .chatConfiguration(ChatConfiguration.builder()
+                .temperature(Property.ofValue(0.1))
+                .seed(Property.ofValue(123456789))
+                .build())
+            .build();
+
+        var ragOutput = rag.run(runContext);
+        assertThat(ragOutput.getTextOutput()).isNotNull();
+
+        // Verify that the table was created and data stored correctly
+        try (Connection conn = DriverManager.getConnection(
+            String.format("jdbc:postgresql://%s:%d/%s", pgHost, pgPort, database), user, password);
+             Statement stmt = conn.createStatement();
+             ResultSet rs = stmt.executeQuery("SELECT COUNT(*) FROM " + customTable)) {
+            assertThat(rs.next()).isTrue();
+            assertThat(rs.getInt(1)).isGreaterThan(0);
+        }
+    }
+}


### PR DESCRIPTION
closes https://github.com/kestra-io/kestra-ee/issues/4718

<!-- Thanks for submitting a Pull Request to kestra. To help us review your contribution, please follow the guidelines below:

- Make sure that your commits follow the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) specification e.g. `feat(ui): add a new navigation menu item` or `fix(core): fix a bug in the core model` or `docs: update the README.md`. This will help us automatically generate the changelog.
- The title should briefly summarize the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share a flow example to help the reviewer understand and QA the change.
- Use "close" to automatically close an issue. For example, `close #1234` will close issue #1234. -->

### What changes are being made and why?
<!-- Please include a brief summary of the changes included in this PR e.g. closes #1234. -->

---

### How the changes have been QAed?

<!-- Include example code that shows how this PR has been QAed. The code should present a complete yet easily reproducible flow.

```yaml
# Your example flow code here
```

Note that this is not a replacement for unit tests but rather a way to demonstrate how the changes work in a real-life scenario, as the end-user would experience them.

Remove this section if this change applies to all flows or to the documentation only. -->

---

### Setup Instructions

<!--If there are any setup requirements like API keys or trial accounts, kindly include brief bullet-points-description outlining the setup process below.

- [External System Documentation](URL)
- Steps to set up the necessary resources

If there are no setup requirements, you can remove this section.

Thank you for your contribution. ❤️  -->

---

### Contributor Checklist ✅

- [ ] PR Title and commits follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Add a `closes #ISSUE_ID` or `fixes #ISSUE_ID` in the description if the PR relates to an opened issue.
- [ ] Documentation updated (plugin docs from `@Schema` for properties and outputs, `@Plugin` with examples, `README.md` file with basic knowledge and specifics).
- [ ] Setup instructions included if needed (API keys, accounts, etc.).
- [ ] Prefix all rendered properties by `r` not `rendered` (eg: `rHost`).
- [ ] Use `runContext.logger()` to log enough important infos where it's needed and with the best level (DEBUG, INFO, WARN or ERROR).

⚙️ **Properties**
- [ ] Properties are declared with `Property<T>` carrier type, do **not** use `@PluginProperty`.
- [ ] Mandatory properties must be annotated with `@NotNull` and checked during the rendering.
- [ ] You can model a JSON thanks to a simple `Property<Map<String, Object>>`.

🌐 **HTTP**
- [ ] Must use Kestra’s internal HTTP client from `io.kestra.core.http.client`

📦 **JSON**
- [ ] If you are serializing response from an external API, you may have to add a `@JsonIgnoreProperties(ignoreUnknown = true)` at the mapped class level. So that we will avoid to crash the plugin if the provider add a new field suddenly.
- [ ] Must use Jackson mappers provided by core (`io.kestra.core.serializers`)

✨ **New plugins / subplugins**
- [ ] Make sure your new plugin is configured like mentioned [here](https://kestra.io/docs/plugin-developer-guide/gradle#mandatory-configuration).
- [ ] Add a `package-info.java` under each sub package respecting [this format](https://github.com/kestra-io/plugin-odoo/blob/main/src/main/java/io/kestra/plugin/odoo/package-info.java) and choosing the right category.
- [ ] Icons added in `src/main/resources/icons` in SVG format and not in thumbnail (keep it big):
  - `plugin-icon.svg`
  - One icon per package, e.g. `io.kestra.plugin.aws.svg`
  - For subpackages, e.g. `io.kestra.plugin.aws.s3`, add `io.kestra.plugin.aws.s3.svg`
    See example [here](https://github.com/kestra-io/plugin-elasticsearch/blob/master/src/main/java/io/kestra/plugin/elasticsearch/Search.java#L76).
- [ ] Use `"{{ secret('YOUR_SECRET') }}"` in the examples for sensible infos such as an API KEY.
- [ ] If you are fetching data (one, many or too many), you must add a `Property<FetchType> fetchType` to be able to use `FETCH_ONE`, `FETCH` and even `STORE` to store big amount of data in the internal storage.
- [ ] Align the `"""` to close examples blocks with the flow id.

🧪 **Tests**
- [ ] Unit Tests added or updated to cover the change (using the `RunContext` to actually run tasks).
- [ ] Add sanity checks if possible with a YAML flow inside `src/test/resources/flows`.
- [ ] Avoid disabling tests for CI. Instead, configure a local environment whenever it's possible with `.github/setup-unit.sh` (which can be executed locally and in the CI) all along with a new `docker-compose-ci.yml` file (do **not** edit the existing `docker-compose.yml`).
- [ ] Provide screenshots from your QA / tests locally in the PR description. The goal here is to use the JAR of the plugin and directly test it locally in Kestra UI to ensure it integrates well.

📤 **Outputs**
- [ ] Do not send back as outputs the same infos you already have in your properties.
- [ ] If you do not have any output use `VoidOutput`.
- [ ] Do not output twice the same infos (eg: a status code, an error code saying the same thing...).
