### PR TITLE
feat: add promptCaching option and fix expression spacing in examples

### DIFF
--- a/src/main/java/io/kestra/plugin/ai/agent/AIAgent.java
+++ b/src/main/java/io/kestra/plugin/ai/agent/AIAgent.java
@@ -267,7 +267,7 @@ import static io.kestra.core.utils.Rethrow.throwFunction;
             title = """
                 Perform market research with an AI Agent using a web search retriever and save the findings as a Markdown report.
                 The retriever gathers up-to-date information, the agent summarizes it, and the filesystem tool writes the result to the task working directory.
-                Mount {{workingDir}} to a container path (e.g., /tmp) so the generated report file is accessible and can be collected with `outputFiles`.""",
+                Mount {{ workingDir }} to a container path (e.g., /tmp) so the generated report file is accessible and can be collected with `outputFiles`.""",
             code = """
                 id: market_research_agent
                 namespace: company.ai
@@ -310,7 +310,7 @@ import static io.kestra.core.utils.Rethrow.throwFunction;
                       - type: io.kestra.plugin.ai.tool.DockerMcpClient
                         image: mcp/filesystem
                         command: ["/tmp"]
-                        binds: ["{{workingDir}}:/tmp"] # mount host_path:container_path to access the generated report
+                        binds: ["{{ workingDir }}:/tmp"] # mount host_path:container_path to access the generated report
                     outputFiles:
                       - report.md
                 """

--- a/src/main/java/io/kestra/plugin/ai/completion/ChatCompletion.java
+++ b/src/main/java/io/kestra/plugin/ai/completion/ChatCompletion.java
@@ -75,7 +75,7 @@ import static io.kestra.plugin.ai.domain.ChatMessageType.*;
                           - type: SYSTEM
                             content: You are a helpful assistant, answer concisely, avoid overly casual language or unnecessary verbosity.
                           - type: USER
-                            content: "{{inputs.prompt}}"
+                            content: "{{ inputs.prompt }}"
                     """
             }
         ),
@@ -102,7 +102,7 @@ import static io.kestra.plugin.ai.domain.ChatMessageType.*;
                           - type: SYSTEM
                             content: You are a helpful assistant, answer concisely, avoid overly casual language or unnecessary verbosity.
                           - type: USER
-                            content: "{{inputs.prompt}}"
+                            content: "{{ inputs.prompt }}"
                         tools:
                           - type: io.kestra.plugin.ai.tool.GoogleCustomWebSearch
                             apiKey: "{{ secret('GOOGLE_SEARCH_API_KEY') }}"
@@ -144,7 +144,7 @@ import static io.kestra.plugin.ai.domain.ChatMessageType.*;
                               type: string
                       messages:
                       - type: USER
-                        content: "{{inputs.prompt}}"
+                        content: "{{ inputs.prompt }}"
                 """
         )
     },

--- a/src/main/java/io/kestra/plugin/ai/domain/ChatConfiguration.java
+++ b/src/main/java/io/kestra/plugin/ai/domain/ChatConfiguration.java
@@ -97,6 +97,15 @@ public class ChatConfiguration {
     @Nullable
     private Property<Integer> maxToken;
 
+    @Schema(
+        title = "Enable Prompt Caching",
+        description = """
+            When enabled, instructs the provider to cache system messages and tool definitions across requests.
+            This can significantly reduce latency and cost for repeated calls with the same system prompt or tools.
+            Currently supported by Anthropic only; other providers silently ignore this setting."""
+    )
+    private Property<Boolean> promptCaching;
+
     public dev.langchain4j.model.chat.request.ResponseFormat computeResponseFormat(RunContext runContext) throws IllegalVariableEvaluationException {
         if (responseFormat == null) {
             return dev.langchain4j.model.chat.request.ResponseFormat.TEXT;

--- a/src/main/java/io/kestra/plugin/ai/embeddings/KestraKVStore.java
+++ b/src/main/java/io/kestra/plugin/ai/embeddings/KestraKVStore.java
@@ -68,7 +68,7 @@ public class KestraKVStore extends EmbeddingStoreProvider {
 
     @Schema(title = "The name of the KV pair to use")
     @Builder.Default
-    private Property<String> kvName = Property.ofExpression("{{flow.id}}-embedding-store");
+    private Property<String> kvName = Property.ofExpression("{{ flow.id }}-embedding-store");
 
     @Override
     public EmbeddingStore<TextSegment> embeddingStore(RunContext runContext, int dimension, boolean drop) throws IOException, IllegalVariableEvaluationException {

--- a/src/main/java/io/kestra/plugin/ai/memory/KestraKVStore.java
+++ b/src/main/java/io/kestra/plugin/ai/memory/KestraKVStore.java
@@ -69,7 +69,7 @@ import lombok.experimental.SuperBuilder;
                     memory:
                       type: io.kestra.plugin.ai.memory.KestraKVStore
                     systemMessage: You are a helpful assistant, answer concisely
-                    prompt: "{{inputs.first}}"
+                    prompt: "{{ inputs.first }}"
 
                   - id: second
                     type: io.kestra.plugin.ai.rag.ChatCompletion
@@ -87,7 +87,7 @@ import lombok.experimental.SuperBuilder;
                       type: io.kestra.plugin.ai.memory.KestraKVStore
                       drop: AFTER_TASKRUN
                     systemMessage: You are a helpful assistant, answer concisely
-                    prompt: "{{inputs.second}}"
+                    prompt: "{{ inputs.second }}"
                 """
         ),
     },

--- a/src/main/java/io/kestra/plugin/ai/memory/PostgreSQL.java
+++ b/src/main/java/io/kestra/plugin/ai/memory/PostgreSQL.java
@@ -60,7 +60,7 @@ import lombok.experimental.SuperBuilder;
                       password: secret
                       tableName: my_custom_memory_table
                     systemMessage: You are a helpful assistant, answer concisely
-                    prompt: "{{inputs.first}}"
+                    prompt: "{{ inputs.first }}"
                 """
         )
     }

--- a/src/main/java/io/kestra/plugin/ai/memory/Redis.java
+++ b/src/main/java/io/kestra/plugin/ai/memory/Redis.java
@@ -69,7 +69,7 @@ import redis.clients.jedis.Jedis;
                       host: localhost
                       port: 6379
                     systemMessage: You are a helpful assistant, answer concisely
-                    prompt: "{{inputs.first}}"
+                    prompt: "{{ inputs.first }}"
 
                   - id: second
                     type: io.kestra.plugin.ai.rag.ChatCompletion
@@ -89,7 +89,7 @@ import redis.clients.jedis.Jedis;
                       port: 6379
                       drop: AFTER_TASKRUN
                     systemMessage: You are a helpful assistant, answer concisely
-                    prompt: "{{inputs.second}}"
+                    prompt: "{{ inputs.second }}"
                 """
         )
     }

--- a/src/main/java/io/kestra/plugin/ai/provider/AmazonBedrock.java
+++ b/src/main/java/io/kestra/plugin/ai/provider/AmazonBedrock.java
@@ -66,7 +66,7 @@ import software.amazon.awssdk.services.bedrockruntime.BedrockRuntimeClient;
                           - type: SYSTEM
                             content: You are a helpful assistant, answer concisely, avoid overly casual language or unnecessary verbosity.
                           - type: USER
-                            content: "{{inputs.prompt}}"
+                            content: "{{ inputs.prompt }}"
                     """
             }
         )

--- a/src/main/java/io/kestra/plugin/ai/provider/Anthropic.java
+++ b/src/main/java/io/kestra/plugin/ai/provider/Anthropic.java
@@ -62,7 +62,7 @@ import lombok.experimental.SuperBuilder;
                           - type: SYSTEM
                             content: You are a helpful assistant, answer concisely, avoid overly casual language or unnecessary verbosity.
                           - type: USER
-                            content: "{{inputs.prompt}}"
+                            content: "{{ inputs.prompt }}"
                     """
             }
         )

--- a/src/main/java/io/kestra/plugin/ai/provider/Anthropic.java
+++ b/src/main/java/io/kestra/plugin/ai/provider/Anthropic.java
@@ -112,7 +112,9 @@ public class Anthropic extends ModelProvider {
             .thinkingType(thinkingEnabled ? ENABLED : null)
             .thinkingBudgetTokens(thinkingBudgetTokens)
             .returnThinking(runContext.render(configuration.getReturnThinking()).as(Boolean.class).orElse(null))
-            .maxTokens(runContext.render(configuration.getMaxToken()).as(Integer.class).orElse(null));
+            .maxTokens(runContext.render(configuration.getMaxToken()).as(Integer.class).orElse(null))
+            .cacheSystemMessages(runContext.render(configuration.getPromptCaching()).as(Boolean.class).orElse(null))
+            .cacheTools(runContext.render(configuration.getPromptCaching()).as(Boolean.class).orElse(null));
 
         JdkHttpClientBuilder httpClientBuilder = buildHttpClientWithPemIfAvailable(runContext);
         if (httpClientBuilder != null) {

--- a/src/main/java/io/kestra/plugin/ai/provider/AzureOpenAI.java
+++ b/src/main/java/io/kestra/plugin/ai/provider/AzureOpenAI.java
@@ -65,7 +65,7 @@ import lombok.experimental.SuperBuilder;
                           - type: SYSTEM
                             content: You are a helpful assistant, answer concisely, avoid overly casual language or unnecessary verbosity.
                           - type: USER
-                            content: "{{inputs.prompt}}"
+                            content: "{{ inputs.prompt }}"
                     """
             }
         )

--- a/src/main/java/io/kestra/plugin/ai/provider/DeepSeek.java
+++ b/src/main/java/io/kestra/plugin/ai/provider/DeepSeek.java
@@ -45,7 +45,7 @@ import lombok.experimental.SuperBuilder;
                           - type: SYSTEM
                             content: You are a helpful assistant, answer concisely, avoid overly casual language or unnecessary verbosity.
                           - type: USER
-                            content: "{{inputs.prompt}}"
+                            content: "{{ inputs.prompt }}"
                     """
             }
         )

--- a/src/main/java/io/kestra/plugin/ai/provider/GitHubModels.java
+++ b/src/main/java/io/kestra/plugin/ai/provider/GitHubModels.java
@@ -61,7 +61,7 @@ import lombok.experimental.SuperBuilder;
                           - type: SYSTEM
                             content: You are a helpful assistant, answer concisely.
                           - type: USER
-                            content: "{{inputs.prompt}}"
+                            content: "{{ inputs.prompt }}"
                     """
             }
         )

--- a/src/main/java/io/kestra/plugin/ai/provider/GoogleGemini.java
+++ b/src/main/java/io/kestra/plugin/ai/provider/GoogleGemini.java
@@ -66,7 +66,7 @@ import lombok.experimental.SuperBuilder;
                           - type: SYSTEM
                             content: You are a helpful assistant, answer concisely, avoid overly casual language or unnecessary verbosity.
                           - type: USER
-                            content: "{{inputs.prompt}}"
+                            content: "{{ inputs.prompt }}"
                     """
             }
         ),
@@ -99,7 +99,7 @@ import lombok.experimental.SuperBuilder;
                           - type: SYSTEM
                             content: You are a helpful assistant, answer concisely, avoid overly casual language or unnecessary verbosity.
                           - type: USER
-                            content: "{{inputs.prompt}}"
+                            content: "{{ inputs.prompt }}"
                     """
             }
         )

--- a/src/main/java/io/kestra/plugin/ai/provider/GoogleVertexAI.java
+++ b/src/main/java/io/kestra/plugin/ai/provider/GoogleVertexAI.java
@@ -62,7 +62,7 @@ import lombok.experimental.SuperBuilder;
                           - type: SYSTEM
                             content: You are a helpful assistant, answer concisely, avoid overly casual language or unnecessary verbosity.
                           - type: USER
-                            content: "{{inputs.prompt}}"
+                            content: "{{ inputs.prompt }}"
                     """
             }
         )

--- a/src/main/java/io/kestra/plugin/ai/provider/HuggingFace.java
+++ b/src/main/java/io/kestra/plugin/ai/provider/HuggingFace.java
@@ -45,7 +45,7 @@ import lombok.experimental.SuperBuilder;
                           - type: SYSTEM
                             content: You are a helpful assistant, answer concisely, avoid overly casual language or unnecessary verbosity.
                           - type: USER
-                            content: "{{inputs.prompt}}"
+                            content: "{{ inputs.prompt }}"
                     """
             }
         )

--- a/src/main/java/io/kestra/plugin/ai/provider/LocalAI.java
+++ b/src/main/java/io/kestra/plugin/ai/provider/LocalAI.java
@@ -56,7 +56,7 @@ import lombok.experimental.SuperBuilder;
                           - type: SYSTEM
                             content: You are a helpful assistant, answer concisely, avoid overly casual language or unnecessary verbosity.
                           - type: USER
-                            content: "{{inputs.prompt}}"
+                            content: "{{ inputs.prompt }}"
                     """
             }
         )

--- a/src/main/java/io/kestra/plugin/ai/provider/MistralAI.java
+++ b/src/main/java/io/kestra/plugin/ai/provider/MistralAI.java
@@ -64,7 +64,7 @@ import static dev.langchain4j.model.chat.Capability.RESPONSE_FORMAT_JSON_SCHEMA;
                           - type: SYSTEM
                             content: You are a helpful assistant, answer concisely, avoid overly casual language or unnecessary verbosity.
                           - type: USER
-                            content: "{{inputs.prompt}}"
+                            content: "{{ inputs.prompt }}"
                     """
             }
         )

--- a/src/main/java/io/kestra/plugin/ai/provider/OciGenAI.java
+++ b/src/main/java/io/kestra/plugin/ai/provider/OciGenAI.java
@@ -65,7 +65,7 @@ import lombok.experimental.SuperBuilder;
                           - type: SYSTEM
                             content: You are a helpful assistant, answer concisely, avoid overly casual language or unnecessary verbosity.
                           - type: USER
-                            content: "{{inputs.prompt}}"
+                            content: "{{ inputs.prompt }}"
                     """
             }
         )

--- a/src/main/java/io/kestra/plugin/ai/provider/Ollama.java
+++ b/src/main/java/io/kestra/plugin/ai/provider/Ollama.java
@@ -61,7 +61,7 @@ import lombok.experimental.SuperBuilder;
                           - type: SYSTEM
                             content: You are a helpful assistant, answer concisely, avoid overly casual language or unnecessary verbosity.
                           - type: USER
-                            content: "{{inputs.prompt}}"
+                            content: "{{ inputs.prompt }}"
                     """
             }
         )

--- a/src/main/java/io/kestra/plugin/ai/provider/OpenAI.java
+++ b/src/main/java/io/kestra/plugin/ai/provider/OpenAI.java
@@ -46,7 +46,7 @@ import lombok.experimental.SuperBuilder;
                           - type: SYSTEM
                             content: You are a helpful assistant, answer concisely, avoid overly casual language or unnecessary verbosity.
                           - type: USER
-                            content: "{{inputs.prompt}}"
+                            content: "{{ inputs.prompt }}"
                     """
             }
         )

--- a/src/main/java/io/kestra/plugin/ai/provider/OpenRouter.java
+++ b/src/main/java/io/kestra/plugin/ai/provider/OpenRouter.java
@@ -61,7 +61,7 @@ import lombok.experimental.SuperBuilder;
                           - type: SYSTEM
                             content: You are a helpful assistant, answer concisely, avoid overly casual language or unnecessary verbosity.
                           - type: USER
-                            content: "{{inputs.prompt}}"
+                            content: "{{ inputs.prompt }}"
                     """
             }
         )

--- a/src/main/java/io/kestra/plugin/ai/provider/WorkersAI.java
+++ b/src/main/java/io/kestra/plugin/ai/provider/WorkersAI.java
@@ -58,7 +58,7 @@ import lombok.experimental.SuperBuilder;
                           - type: SYSTEM
                             content: You are a helpful assistant, answer concisely, avoid overly casual language or unnecessary verbosity.
                           - type: USER
-                            content: "{{inputs.prompt}}"
+                            content: "{{ inputs.prompt }}"
                     """
             }
         )

--- a/src/main/java/io/kestra/plugin/ai/rag/ChatCompletion.java
+++ b/src/main/java/io/kestra/plugin/ai/rag/ChatCompletion.java
@@ -157,7 +157,7 @@ import static io.kestra.core.utils.Rethrow.throwFunction;
                       type: io.kestra.plugin.ai.memory.KestraKVStore
                       ttl: PT1M
                     systemMessage: You are a helpful assistant, answer concisely
-                    prompt: "{{inputs.first}}"
+                    prompt: "{{ inputs.first }}"
 
                   - id: second
                     type: io.kestra.plugin.ai.rag.ChatCompletion
@@ -171,7 +171,7 @@ import static io.kestra.core.utils.Rethrow.throwFunction;
                     memory:
                       type: io.kestra.plugin.ai.memory.KestraKVStore
                     systemMessage: You are a helpful assistant, answer concisely
-                    prompt: "{{inputs.second}}"
+                    prompt: "{{ inputs.second }}"
 
                 pluginDefaults:
                   - type: io.kestra.plugin.ai.provider.GoogleGemini

--- a/src/main/java/io/kestra/plugin/ai/tool/A2AClient.java
+++ b/src/main/java/io/kestra/plugin/ai/tool/A2AClient.java
@@ -52,7 +52,7 @@ import lombok.experimental.SuperBuilder;
                           modelName: gemini-2.5-flash
                           apiKey: "{{ secret('GEMINI_API_KEY') }}"
                         systemMessage: Summarize the user message, then translate it into French using the provided tool.
-                        prompt: "{{inputs.prompt}}"
+                        prompt: "{{ inputs.prompt }}"
                         tools:
                           - type: io.kestra.plugin.ai.tool.A2AClient
                             description: Translation expert

--- a/src/main/java/io/kestra/plugin/ai/tool/AIAgent.java
+++ b/src/main/java/io/kestra/plugin/ai/tool/AIAgent.java
@@ -64,7 +64,7 @@ import static io.kestra.core.utils.Rethrow.throwFunction;
                           modelName: gemini-2.5-flash
                           apiKey: "{{ secret('GEMINI_API_KEY') }}"
                         systemMessage: Summarize the user message, then translate it into French using the provided tool.
-                        prompt: "{{inputs.prompt}}"
+                        prompt: "{{ inputs.prompt }}"
                         tools:
                           - type: io.kestra.plugin.ai.tool.AIAgent
                             description: Translation expert

--- a/src/main/java/io/kestra/plugin/ai/tool/DockerMcpClient.java
+++ b/src/main/java/io/kestra/plugin/ai/tool/DockerMcpClient.java
@@ -82,7 +82,7 @@ import static io.kestra.core.utils.Rethrow.throwSupplier;
                             image: mcp/filesystem
                             command: ["/tmp"]
                             # Mount the container path to the task working directory to access the generated file
-                            binds: ["{{workingDir}}:/tmp"]
+                            binds: ["{{ workingDir }}:/tmp"]
                         outputFiles:
                           - hello.txt"""
             }

--- a/src/main/java/io/kestra/plugin/ai/tool/SseMcpClient.java
+++ b/src/main/java/io/kestra/plugin/ai/tool/SseMcpClient.java
@@ -43,7 +43,7 @@ import lombok.experimental.SuperBuilder;
                     tasks:
                       - id: agent
                         type: io.kestra.plugin.ai.agent.AIAgent
-                        prompt: "{{inputs.prompt}}"
+                        prompt: "{{ inputs.prompt }}"
                         provider:
                           type: io.kestra.plugin.ai.provider.GoogleGemini
                           modelName: gemini-2.5-flash

--- a/src/main/java/io/kestra/plugin/ai/tool/StreamableHttpMcpClient.java
+++ b/src/main/java/io/kestra/plugin/ai/tool/StreamableHttpMcpClient.java
@@ -43,7 +43,7 @@ import lombok.experimental.SuperBuilder;
                     tasks:
                       - id: agent
                         type: io.kestra.plugin.ai.agent.AIAgent
-                        prompt: "{{inputs.prompt}}"
+                        prompt: "{{ inputs.prompt }}"
                         provider:
                           type: io.kestra.plugin.ai.provider.GoogleGemini
                           modelName: gemini-2.5-flash

--- a/src/test/java/io/kestra/plugin/ai/completion/ChatCompletionTest.java
+++ b/src/test/java/io/kestra/plugin/ai/completion/ChatCompletionTest.java
@@ -540,6 +540,38 @@ class ChatCompletionTest extends ContainerTest {
 
     @EnabledIfEnvironmentVariable(named = "ANTHROPIC_API_KEY", matches = ".*")
     @Test
+    void testChatCompletionAnthropicAI_givenPromptCachingEnabled() throws Exception {
+        RunContext runContext = runContextFactory.of(
+            Map.of(
+                "modelName", AnthropicChatModelName.CLAUDE_3_HAIKU_20240307,
+                "apiKey", ANTHROPIC_API_KEY,
+                "messages", List.of(
+                    ChatMessage.builder().type(ChatMessageType.USER).content("Hello, my name is John").build()
+                )
+            )
+        );
+
+        ChatCompletion task = ChatCompletion.builder()
+            .messages(Property.ofExpression("{{ messages }}"))
+            .configuration(ChatConfiguration.builder().temperature(Property.ofValue(0.1)).promptCaching(Property.ofValue(true)).build())
+            .provider(
+                Anthropic.builder()
+                    .type(Anthropic.class.getName())
+                    .modelName(Property.ofExpression("{{ modelName }}"))
+                    .apiKey(Property.ofExpression("{{ apiKey }}"))
+                    .build()
+            )
+            .build();
+
+        ChatCompletion.Output output = task.run(runContext);
+
+        assertThat(output.getTextOutput(), notNullValue());
+        assertThat(output.getTextOutput(), containsString("John"));
+        assertThat(output.getRequestDuration(), notNullValue());
+    }
+
+    @EnabledIfEnvironmentVariable(named = "ANTHROPIC_API_KEY", matches = ".*")
+    @Test
     void testChatCompletionAnthropicAI() throws Exception {
         RunContext runContext = runContextFactory.of(
             Map.of(


### PR DESCRIPTION
## Summary
- Adds a `promptCaching` boolean property to `ChatConfiguration`, factorized so all tasks can use it
- When enabled, sets both `cacheSystemMessages` and `cacheTools` on the Anthropic chat model builder
- Other providers silently ignore the setting
- Adds a test for prompt caching with the Anthropic provider
- Fixes missing spaces in Kestra expressions (`{{inputs.prompt}}` → `{{ inputs.prompt }}`) across 27 example files

## Test plan
- [ ] Verify `testChatCompletionAnthropicAI_givenPromptCachingEnabled` passes with `ANTHROPIC_API_KEY` set
- [ ] Verify existing Anthropic tests still pass (no regression)
- [ ] Verify build compiles cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)