### PR TITLE
feat: add Skill tool for AI agents

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -109,6 +109,9 @@ dependencies {
     implementation "dev.langchain4j:langchain4j-agentic"
     implementation "dev.langchain4j:langchain4j-agentic-a2a"
 
+    // skills
+    implementation "dev.langchain4j:langchain4j-skills:1.12.2-beta22"
+
     implementation "com.azure:azure-identity" // For Azure OpenAI
 
     implementation "io.opentelemetry:opentelemetry-api"

--- a/src/main/java/io/kestra/plugin/ai/tool/Skill.java
+++ b/src/main/java/io/kestra/plugin/ai/tool/Skill.java
@@ -19,6 +19,8 @@ import io.kestra.core.utils.ListUtils;
 import io.kestra.plugin.ai.domain.ToolProvider;
 
 import dev.langchain4j.agent.tool.ToolSpecification;
+import dev.langchain4j.data.message.UserMessage;
+import dev.langchain4j.invocation.InvocationContext;
 import dev.langchain4j.service.tool.ToolExecutor;
 import dev.langchain4j.service.tool.ToolProviderRequest;
 import dev.langchain4j.skills.DefaultSkill;
@@ -141,7 +143,12 @@ public class Skill extends ToolProvider {
         }
 
         var skills = Skills.from(skillList);
-        var result = skills.toolProvider().provideTools(ToolProviderRequest.builder().build());
+        var invocationContext = InvocationContext.builder().build();
+        var userMessage = UserMessage.from("placeholder");
+        var result = skills.toolProvider().provideTools(ToolProviderRequest.builder()
+            .invocationContext(invocationContext)
+            .userMessage(userMessage)
+            .build());
         return result.tools();
     }
 

--- a/src/main/java/io/kestra/plugin/ai/tool/Skill.java
+++ b/src/main/java/io/kestra/plugin/ai/tool/Skill.java
@@ -1,0 +1,321 @@
+package io.kestra.plugin.ai.tool;
+
+import java.io.InputStream;
+import java.net.URI;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+
+import io.kestra.core.exceptions.IllegalVariableEvaluationException;
+import io.kestra.core.models.annotations.Example;
+import io.kestra.core.models.annotations.Plugin;
+import io.kestra.core.models.annotations.PluginProperty;
+import io.kestra.core.models.property.Property;
+import io.kestra.core.runners.RunContext;
+import io.kestra.core.serializers.JacksonMapper;
+import io.kestra.core.utils.ListUtils;
+import io.kestra.plugin.ai.domain.ToolProvider;
+
+import dev.langchain4j.agent.tool.ToolExecutionRequest;
+import dev.langchain4j.agent.tool.ToolSpecification;
+import dev.langchain4j.exception.ToolExecutionException;
+import dev.langchain4j.model.chat.request.json.JsonObjectSchema;
+import dev.langchain4j.model.chat.request.json.JsonStringSchema;
+import dev.langchain4j.service.tool.ToolExecutor;
+import dev.langchain4j.skills.DefaultSkill;
+import dev.langchain4j.skills.DefaultSkillResource;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+
+@Getter
+@SuperBuilder
+@NoArgsConstructor
+@Plugin(
+    examples = {
+        @Example(
+            title = "Use skills to provide structured instructions to an AI agent",
+            full = true,
+            code = {
+                """
+                    id: agent_with_skills
+                    namespace: company.ai
+
+                    tasks:
+                      - id: agent
+                        type: io.kestra.plugin.ai.agent.AIAgent
+                        prompt: Translate the following text to French - "Hello, how are you today?"
+                        provider:
+                          type: io.kestra.plugin.ai.provider.GoogleGemini
+                          modelName: gemini-2.5-flash
+                          apiKey: "{{ secret('GEMINI_API_KEY') }}"
+                        tools:
+                          - type: io.kestra.plugin.ai.tool.Skill
+                            skills:
+                              - name: translation_expert
+                                description: Expert translator for multiple languages
+                                content: |
+                                  You are an expert translator. When translating text:
+                                  1. Preserve the original meaning and tone
+                                  2. Use natural phrasing in the target language
+                                  3. Keep proper nouns unchanged"""
+            }
+        ),
+    }
+)
+@JsonDeserialize
+@Schema(
+    title = "Provide skills to an AI agent",
+    description = """
+        Exposes langchain4j skills as tools for an AI agent. Skills are structured instructions
+        that the agent can activate on demand. Each skill has a name, description, and content
+        that gets returned when the agent activates it. Skills can also include resources
+        that the agent can read separately."""
+)
+public class Skill extends ToolProvider {
+
+    @Schema(
+        title = "List of skill definitions",
+        description = """
+            Each skill defines a set of structured instructions that the agent can activate.
+            A skill must have a name, description, and either inline content or a content URI
+            pointing to Kestra internal storage."""
+    )
+    @NotNull
+    @PluginProperty
+    private List<SkillDefinition> skills;
+
+    @Override
+    public Map<ToolSpecification, ToolExecutor> tool(RunContext runContext, Map<String, Object> additionalVariables) throws Exception {
+        var skillList = ListUtils.emptyOnNull(skills).stream()
+            .map(def -> buildSkill(runContext, additionalVariables, def))
+            .toList();
+
+        if (skillList.isEmpty()) {
+            throw new IllegalArgumentException("At least one skill must be defined");
+        }
+
+        // Build a map for quick lookup by name
+        var skillMap = new HashMap<String, dev.langchain4j.skills.Skill>();
+        for (var skill : skillList) {
+            skillMap.put(skill.name(), skill);
+        }
+
+        // Build a concise skill catalog for the tool description
+        var catalogBuilder = new StringBuilder();
+        for (var skill : skillList) {
+            catalogBuilder.append("- ").append(skill.name()).append(": ").append(skill.description()).append("\n");
+        }
+
+        var tools = new HashMap<ToolSpecification, ToolExecutor>();
+
+        // activate_skill tool
+        var activateSpec = ToolSpecification.builder()
+            .name("activate_skill")
+            .description("Activates a skill and returns its content. Available skills:\n" + catalogBuilder)
+            .parameters(
+                JsonObjectSchema.builder()
+                    .addProperty("skill_name", JsonStringSchema.builder()
+                        .description("The name of the skill to activate")
+                        .build())
+                    .required("skill_name")
+                    .build()
+            )
+            .build();
+        tools.put(activateSpec, new ActivateSkillExecutor(runContext, skillMap));
+
+        // read_skill_resource tool (only when at least one skill has resources)
+        var hasResources = skillList.stream()
+            .anyMatch(skill -> !ListUtils.isEmpty(skill.resources()));
+        if (hasResources) {
+            var readResourceSpec = ToolSpecification.builder()
+                .name("read_skill_resource")
+                .description("Reads a resource file attached to a skill. Provide the skill name and the relative path of the resource.")
+                .parameters(
+                    JsonObjectSchema.builder()
+                        .addProperty("skill_name", JsonStringSchema.builder()
+                            .description("The name of the skill that owns the resource")
+                            .build())
+                        .addProperty("relative_path", JsonStringSchema.builder()
+                            .description("The relative path of the resource within the skill")
+                            .build())
+                        .required("skill_name", "relative_path")
+                        .build()
+                )
+                .build();
+            tools.put(readResourceSpec, new ReadResourceExecutor(runContext, skillMap));
+        }
+
+        return tools;
+    }
+
+    private dev.langchain4j.skills.Skill buildSkill(RunContext runContext, Map<String, Object> additionalVariables, SkillDefinition def) {
+        try {
+            var rName = runContext.render(def.getName()).as(String.class, additionalVariables).orElseThrow();
+            var rDescription = runContext.render(def.getDescription()).as(String.class, additionalVariables).orElseThrow();
+            var rContent = def.getContent() != null
+                ? runContext.render(def.getContent()).as(String.class, additionalVariables).orElse(null)
+                : null;
+            var rContentUri = def.getContentUri() != null
+                ? runContext.render(def.getContentUri()).as(String.class, additionalVariables).orElse(null)
+                : null;
+
+            if (rContent == null && rContentUri == null) {
+                throw new IllegalArgumentException("Skill '" + rName + "' must have either 'content' or 'contentUri' set");
+            }
+            if (rContent != null && rContentUri != null) {
+                throw new IllegalArgumentException("Skill '" + rName + "' must have either 'content' or 'contentUri' set, not both");
+            }
+
+            var resolvedContent = rContent;
+            if (rContentUri != null) {
+                try (InputStream file = runContext.storage().getFile(URI.create(rContentUri))) {
+                    resolvedContent = new String(file.readAllBytes());
+                }
+            }
+
+            var resources = ListUtils.emptyOnNull(def.getResources()).stream()
+                .map(resourceDef -> {
+                    try {
+                        var rRelativePath = runContext.render(resourceDef.getRelativePath()).as(String.class, additionalVariables).orElseThrow();
+                        var rResourceContent = runContext.render(resourceDef.getContent()).as(String.class, additionalVariables).orElseThrow();
+                        return (dev.langchain4j.skills.SkillResource) DefaultSkillResource.builder()
+                            .relativePath(rRelativePath)
+                            .content(rResourceContent)
+                            .build();
+                    } catch (IllegalVariableEvaluationException e) {
+                        throw new IllegalStateException("Failed to render skill resource properties", e);
+                    }
+                })
+                .toList();
+
+            return DefaultSkill.builder()
+                .name(rName)
+                .description(rDescription)
+                .content(resolvedContent)
+                .resources(resources)
+                .build();
+        } catch (IllegalVariableEvaluationException e) {
+            throw new IllegalStateException("Failed to render skill properties", e);
+        } catch (IllegalArgumentException | IllegalStateException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new IllegalStateException("Failed to build skill", e);
+        }
+    }
+
+    private static class ActivateSkillExecutor implements ToolExecutor {
+        private final RunContext runContext;
+        private final Map<String, dev.langchain4j.skills.Skill> skillMap;
+
+        ActivateSkillExecutor(RunContext runContext, Map<String, dev.langchain4j.skills.Skill> skillMap) {
+            this.runContext = runContext;
+            this.skillMap = skillMap;
+        }
+
+        @Override
+        public String execute(ToolExecutionRequest request, Object memoryId) {
+            runContext.logger().debug("activate_skill request: {}", request);
+            try {
+                var parameters = JacksonMapper.toMap(request.arguments());
+                var skillName = (String) parameters.get("skill_name");
+                var skill = skillMap.get(skillName);
+                if (skill == null) {
+                    throw new IllegalArgumentException("Skill not found: '" + skillName + "'. Available skills: " + skillMap.keySet());
+                }
+                runContext.logger().info("Activated skill: {}", skillName);
+                return skill.content();
+            } catch (Exception e) {
+                throw new ToolExecutionException(e);
+            }
+        }
+    }
+
+    private static class ReadResourceExecutor implements ToolExecutor {
+        private final RunContext runContext;
+        private final Map<String, dev.langchain4j.skills.Skill> skillMap;
+
+        ReadResourceExecutor(RunContext runContext, Map<String, dev.langchain4j.skills.Skill> skillMap) {
+            this.runContext = runContext;
+            this.skillMap = skillMap;
+        }
+
+        @Override
+        public String execute(ToolExecutionRequest request, Object memoryId) {
+            runContext.logger().debug("read_skill_resource request: {}", request);
+            try {
+                var parameters = JacksonMapper.toMap(request.arguments());
+                var skillName = (String) parameters.get("skill_name");
+                var relativePath = (String) parameters.get("relative_path");
+
+                var skill = skillMap.get(skillName);
+                if (skill == null) {
+                    throw new IllegalArgumentException("Skill not found: '" + skillName + "'. Available skills: " + skillMap.keySet());
+                }
+
+                var resource = ListUtils.emptyOnNull(skill.resources()).stream()
+                    .filter(r -> r.relativePath().equals(relativePath))
+                    .findFirst()
+                    .orElseThrow(() -> new IllegalArgumentException(
+                        "Resource not found: '" + relativePath + "' in skill '" + skillName + "'"
+                    ));
+
+                runContext.logger().info("Read resource '{}' from skill '{}'", relativePath, skillName);
+                return resource.content();
+            } catch (Exception e) {
+                throw new ToolExecutionException(e);
+            }
+        }
+    }
+
+    @Getter
+    @Builder
+    @Schema(title = "A skill definition")
+    public static class SkillDefinition {
+        @Schema(title = "Name of the skill")
+        @NotNull
+        private Property<String> name;
+
+        @Schema(title = "Description of the skill used by the LLM to decide when to activate it")
+        @NotNull
+        private Property<String> description;
+
+        @Schema(
+            title = "Inline content of the skill",
+            description = "Mutually exclusive with 'contentUri'. At least one of 'content' or 'contentUri' must be set."
+        )
+        private Property<String> content;
+
+        @Schema(
+            title = "URI to the skill content in Kestra internal storage",
+            description = "Mutually exclusive with 'content'. At least one of 'content' or 'contentUri' must be set."
+        )
+        @PluginProperty(internalStorageURI = true)
+        private Property<String> contentUri;
+
+        @Schema(
+            title = "Additional resources attached to this skill",
+            description = "Resources the agent can read separately using the 'read_skill_resource' tool."
+        )
+        @PluginProperty
+        private List<ResourceDefinition> resources;
+    }
+
+    @Getter
+    @Builder
+    @Schema(title = "A skill resource definition")
+    public static class ResourceDefinition {
+        @Schema(title = "Relative path of the resource within the skill")
+        @NotNull
+        private Property<String> relativePath;
+
+        @Schema(title = "Content of the resource")
+        @NotNull
+        private Property<String> content;
+    }
+}

--- a/src/main/java/io/kestra/plugin/ai/tool/Skill.java
+++ b/src/main/java/io/kestra/plugin/ai/tool/Skill.java
@@ -66,6 +66,41 @@ import lombok.experimental.SuperBuilder;
                                   3. Keep proper nouns unchanged"""
             }
         ),
+        @Example(
+            title = "Load skill content from Kestra internal storage",
+            full = true,
+            code = {
+                """
+                    id: agent_with_skill_from_storage
+                    namespace: company.ai
+
+                    tasks:
+                      - id: load_instructions
+                        type: io.kestra.core.tasks.storages.LocalFiles
+                        inputs:
+                          coding_guidelines.md: |
+                            You are a senior code reviewer. When reviewing code:
+                            1. Check for security vulnerabilities
+                            2. Ensure proper error handling
+                            3. Verify naming conventions are followed
+                            4. Flag any code duplication
+
+                      - id: agent
+                        type: io.kestra.plugin.ai.agent.AIAgent
+                        prompt: Review this Python function - "def add(a, b): return a + b"
+                        provider:
+                          type: io.kestra.plugin.ai.provider.GoogleGemini
+                          modelName: gemini-2.5-flash
+                          apiKey: "{{ secret('GEMINI_API_KEY') }}"
+                        tools:
+                          - type: io.kestra.plugin.ai.tool.Skill
+                            skills:
+                              - name: code_review_expert
+                                description: Expert code reviewer with strict guidelines
+                                contentUri: "{{ outputs.load_instructions.uris['coding_guidelines.md'] }}"
+                """
+            }
+        ),
     }
 )
 @JsonDeserialize

--- a/src/main/java/io/kestra/plugin/ai/tool/Skill.java
+++ b/src/main/java/io/kestra/plugin/ai/tool/Skill.java
@@ -2,7 +2,8 @@ package io.kestra.plugin.ai.tool;
 
 import java.io.InputStream;
 import java.net.URI;
-import java.util.HashMap;
+import java.nio.charset.StandardCharsets;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 
@@ -14,18 +15,15 @@ import io.kestra.core.models.annotations.Plugin;
 import io.kestra.core.models.annotations.PluginProperty;
 import io.kestra.core.models.property.Property;
 import io.kestra.core.runners.RunContext;
-import io.kestra.core.serializers.JacksonMapper;
 import io.kestra.core.utils.ListUtils;
 import io.kestra.plugin.ai.domain.ToolProvider;
 
-import dev.langchain4j.agent.tool.ToolExecutionRequest;
 import dev.langchain4j.agent.tool.ToolSpecification;
-import dev.langchain4j.exception.ToolExecutionException;
-import dev.langchain4j.model.chat.request.json.JsonObjectSchema;
-import dev.langchain4j.model.chat.request.json.JsonStringSchema;
 import dev.langchain4j.service.tool.ToolExecutor;
+import dev.langchain4j.service.tool.ToolProviderRequest;
 import dev.langchain4j.skills.DefaultSkill;
 import dev.langchain4j.skills.DefaultSkillResource;
+import dev.langchain4j.skills.Skills;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import lombok.Builder;
@@ -75,15 +73,14 @@ import lombok.experimental.SuperBuilder;
                     namespace: company.ai
 
                     tasks:
-                      - id: load_instructions
-                        type: io.kestra.core.tasks.storages.LocalFiles
-                        inputs:
-                          coding_guidelines.md: |
-                            You are a senior code reviewer. When reviewing code:
-                            1. Check for security vulnerabilities
-                            2. Ensure proper error handling
-                            3. Verify naming conventions are followed
-                            4. Flag any code duplication
+                      - id: write_instructions
+                        type: io.kestra.plugin.core.storage.Write
+                        content: |
+                          You are a senior code reviewer. When reviewing code:
+                          1. Check for security vulnerabilities
+                          2. Ensure proper error handling
+                          3. Verify naming conventions are followed
+                          4. Flag any code duplication
 
                       - id: agent
                         type: io.kestra.plugin.ai.agent.AIAgent
@@ -97,7 +94,7 @@ import lombok.experimental.SuperBuilder;
                             skills:
                               - name: code_review_expert
                                 description: Expert code reviewer with strict guidelines
-                                contentUri: "{{ outputs.load_instructions.uris['coding_guidelines.md'] }}"
+                                contentUri: "{{ outputs.write_instructions.uri }}"
                 """
             }
         ),
@@ -135,58 +132,17 @@ public class Skill extends ToolProvider {
             throw new IllegalArgumentException("At least one skill must be defined");
         }
 
-        // Build a map for quick lookup by name
-        var skillMap = new HashMap<String, dev.langchain4j.skills.Skill>();
+        // Validate no duplicate skill names
+        var seenNames = new HashSet<String>();
         for (var skill : skillList) {
-            skillMap.put(skill.name(), skill);
+            if (!seenNames.add(skill.name())) {
+                throw new IllegalArgumentException("Duplicate skill name: '" + skill.name() + "'. Each skill must have a unique name.");
+            }
         }
 
-        // Build a concise skill catalog for the tool description
-        var catalogBuilder = new StringBuilder();
-        for (var skill : skillList) {
-            catalogBuilder.append("- ").append(skill.name()).append(": ").append(skill.description()).append("\n");
-        }
-
-        var tools = new HashMap<ToolSpecification, ToolExecutor>();
-
-        // activate_skill tool
-        var activateSpec = ToolSpecification.builder()
-            .name("activate_skill")
-            .description("Activates a skill and returns its content. Available skills:\n" + catalogBuilder)
-            .parameters(
-                JsonObjectSchema.builder()
-                    .addProperty("skill_name", JsonStringSchema.builder()
-                        .description("The name of the skill to activate")
-                        .build())
-                    .required("skill_name")
-                    .build()
-            )
-            .build();
-        tools.put(activateSpec, new ActivateSkillExecutor(runContext, skillMap));
-
-        // read_skill_resource tool (only when at least one skill has resources)
-        var hasResources = skillList.stream()
-            .anyMatch(skill -> !ListUtils.isEmpty(skill.resources()));
-        if (hasResources) {
-            var readResourceSpec = ToolSpecification.builder()
-                .name("read_skill_resource")
-                .description("Reads a resource file attached to a skill. Provide the skill name and the relative path of the resource.")
-                .parameters(
-                    JsonObjectSchema.builder()
-                        .addProperty("skill_name", JsonStringSchema.builder()
-                            .description("The name of the skill that owns the resource")
-                            .build())
-                        .addProperty("relative_path", JsonStringSchema.builder()
-                            .description("The relative path of the resource within the skill")
-                            .build())
-                        .required("skill_name", "relative_path")
-                        .build()
-                )
-                .build();
-            tools.put(readResourceSpec, new ReadResourceExecutor(runContext, skillMap));
-        }
-
-        return tools;
+        var skills = Skills.from(skillList);
+        var result = skills.toolProvider().provideTools(ToolProviderRequest.builder().build());
+        return result.tools();
     }
 
     private dev.langchain4j.skills.Skill buildSkill(RunContext runContext, Map<String, Object> additionalVariables, SkillDefinition def) {
@@ -210,7 +166,7 @@ public class Skill extends ToolProvider {
             var resolvedContent = rContent;
             if (rContentUri != null) {
                 try (InputStream file = runContext.storage().getFile(URI.create(rContentUri))) {
-                    resolvedContent = new String(file.readAllBytes());
+                    resolvedContent = new String(file.readAllBytes(), StandardCharsets.UTF_8);
                 }
             }
 
@@ -241,70 +197,6 @@ public class Skill extends ToolProvider {
             throw e;
         } catch (Exception e) {
             throw new IllegalStateException("Failed to build skill", e);
-        }
-    }
-
-    private static class ActivateSkillExecutor implements ToolExecutor {
-        private final RunContext runContext;
-        private final Map<String, dev.langchain4j.skills.Skill> skillMap;
-
-        ActivateSkillExecutor(RunContext runContext, Map<String, dev.langchain4j.skills.Skill> skillMap) {
-            this.runContext = runContext;
-            this.skillMap = skillMap;
-        }
-
-        @Override
-        public String execute(ToolExecutionRequest request, Object memoryId) {
-            runContext.logger().debug("activate_skill request: {}", request);
-            try {
-                var parameters = JacksonMapper.toMap(request.arguments());
-                var skillName = (String) parameters.get("skill_name");
-                var skill = skillMap.get(skillName);
-                if (skill == null) {
-                    throw new IllegalArgumentException("Skill not found: '" + skillName + "'. Available skills: " + skillMap.keySet());
-                }
-                runContext.logger().info("Activated skill: {}", skillName);
-                return skill.content();
-            } catch (Exception e) {
-                throw new ToolExecutionException(e);
-            }
-        }
-    }
-
-    private static class ReadResourceExecutor implements ToolExecutor {
-        private final RunContext runContext;
-        private final Map<String, dev.langchain4j.skills.Skill> skillMap;
-
-        ReadResourceExecutor(RunContext runContext, Map<String, dev.langchain4j.skills.Skill> skillMap) {
-            this.runContext = runContext;
-            this.skillMap = skillMap;
-        }
-
-        @Override
-        public String execute(ToolExecutionRequest request, Object memoryId) {
-            runContext.logger().debug("read_skill_resource request: {}", request);
-            try {
-                var parameters = JacksonMapper.toMap(request.arguments());
-                var skillName = (String) parameters.get("skill_name");
-                var relativePath = (String) parameters.get("relative_path");
-
-                var skill = skillMap.get(skillName);
-                if (skill == null) {
-                    throw new IllegalArgumentException("Skill not found: '" + skillName + "'. Available skills: " + skillMap.keySet());
-                }
-
-                var resource = ListUtils.emptyOnNull(skill.resources()).stream()
-                    .filter(r -> r.relativePath().equals(relativePath))
-                    .findFirst()
-                    .orElseThrow(() -> new IllegalArgumentException(
-                        "Resource not found: '" + relativePath + "' in skill '" + skillName + "'"
-                    ));
-
-                runContext.logger().info("Read resource '{}' from skill '{}'", relativePath, skillName);
-                return resource.content();
-            } catch (Exception e) {
-                throw new ToolExecutionException(e);
-            }
         }
     }
 

--- a/src/test/java/io/kestra/plugin/ai/agent/AIAgentTest.java
+++ b/src/test/java/io/kestra/plugin/ai/agent/AIAgentTest.java
@@ -27,6 +27,7 @@ import io.kestra.plugin.ai.retriever.EmbeddingStoreRetriever;
 import io.kestra.plugin.ai.retriever.GoogleCustomWebSearch;
 import io.kestra.plugin.ai.retriever.TavilyWebSearch;
 import io.kestra.plugin.ai.tool.DockerMcpClient;
+import io.kestra.plugin.ai.tool.Skill;
 import io.kestra.plugin.ai.tool.StdioMcpClient;
 
 import jakarta.inject.Inject;
@@ -1008,6 +1009,54 @@ class AIAgentTest {
         assertThat(output.getGuardrailViolationMessage()).contains("Message exceeds strict limit");
         assertThat(output.getGuardrailViolationMessage()).doesNotContain("Should never be reached");
         assertThat(output.getTextOutput()).isNull();
+    }
+
+    @EnabledIfEnvironmentVariable(named = "GOOGLE_API_KEY", matches = ".*")
+    @Test
+    void withSkillTool() throws Exception {
+        var runContext = runContextFactory.of(
+            "namespace", Map.of(
+                "modelName", "gemini-2.5-flash",
+                "apiKey", GOOGLE_API_KEY
+            )
+        );
+
+        var agent = AIAgent.builder()
+            .provider(
+                GoogleGemini.builder()
+                    .type(GoogleGemini.class.getName())
+                    .modelName(Property.ofExpression("{{ modelName }}"))
+                    .apiKey(Property.ofExpression("{{ apiKey }}"))
+                    .build()
+            )
+            .tools(
+                List.of(
+                    Skill.builder()
+                        .skills(
+                            List.of(
+                                Skill.SkillDefinition.builder()
+                                    .name(Property.ofValue("translation_expert"))
+                                    .description(Property.ofValue("Expert translator for multiple languages"))
+                                    .content(Property.ofValue(
+                                        "You are an expert translator. When translating text:\n" +
+                                        "1. Preserve the original meaning and tone\n" +
+                                        "2. Use natural phrasing in the target language\n" +
+                                        "3. Keep proper nouns unchanged"
+                                    ))
+                                    .build()
+                            )
+                        )
+                        .build()
+                )
+            )
+            .prompt(Property.ofValue("Translate the following text to French: \"Hello, how are you today?\" Use the available skill to help with the translation."))
+            .configuration(ChatConfiguration.builder().temperature(Property.ofValue(0.1)).seed(Property.ofValue(123456789)).build())
+            .build();
+
+        var output = agent.run(runContext);
+        assertThat(output.getTextOutput()).isNotNull();
+        assertThat(output.getToolExecutions()).isNotEmpty();
+        assertThat(output.getToolExecutions()).extracting("requestName").contains("activate_skill");
     }
 
 }

--- a/src/test/java/io/kestra/plugin/ai/tool/SkillTest.java
+++ b/src/test/java/io/kestra/plugin/ai/tool/SkillTest.java
@@ -1,0 +1,148 @@
+package io.kestra.plugin.ai.tool;
+
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import com.github.tomakehurst.wiremock.WireMockServer;
+
+import io.kestra.core.junit.annotations.KestraTest;
+import io.kestra.core.models.property.Property;
+import io.kestra.core.runners.RunContext;
+import io.kestra.core.runners.RunContextFactory;
+import io.kestra.plugin.ai.completion.ChatCompletion;
+import io.kestra.plugin.ai.domain.ChatConfiguration;
+import io.kestra.plugin.ai.domain.ChatMessage;
+import io.kestra.plugin.ai.domain.ChatMessageType;
+import io.kestra.plugin.ai.provider.OpenAI;
+
+import dev.langchain4j.model.output.FinishReason;
+import jakarta.inject.Inject;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@KestraTest(startRunner = true)
+class SkillTest {
+    @Inject
+    private RunContextFactory runContextFactory;
+
+    @Test
+    void skillWithInlineContent() throws Exception {
+        var wireMock = new WireMockServer(wireMockConfig().dynamicPort());
+        try {
+            wireMock.start();
+
+            // First call: LLM decides to call activate_skill tool
+            wireMock.stubFor(post(urlEqualTo("/v1/chat/completions"))
+                .inScenario("skill-activation")
+                .whenScenarioStateIs("Started")
+                .willReturn(aResponse()
+                    .withStatus(200)
+                    .withHeader("Content-Type", "application/json")
+                    .withBody("""
+                        {
+                          "id": "chatcmpl-1",
+                          "object": "chat.completion",
+                          "model": "gpt-4o-mini",
+                          "choices": [{
+                            "index": 0,
+                            "message": {
+                              "role": "assistant",
+                              "content": null,
+                              "tool_calls": [{
+                                "id": "call_1",
+                                "type": "function",
+                                "function": {
+                                  "name": "activate_skill",
+                                  "arguments": "{\\"skill_name\\": \\"translator\\"}"
+                                }
+                              }]
+                            },
+                            "finish_reason": "tool_calls"
+                          }],
+                          "usage": {"prompt_tokens": 50, "completion_tokens": 20, "total_tokens": 70}
+                        }
+                        """))
+                .willSetStateTo("skill-activated"));
+
+            // Second call: LLM produces final answer after receiving skill content
+            wireMock.stubFor(post(urlEqualTo("/v1/chat/completions"))
+                .inScenario("skill-activation")
+                .whenScenarioStateIs("skill-activated")
+                .willReturn(aResponse()
+                    .withStatus(200)
+                    .withHeader("Content-Type", "application/json")
+                    .withBody("""
+                        {
+                          "id": "chatcmpl-2",
+                          "object": "chat.completion",
+                          "model": "gpt-4o-mini",
+                          "choices": [{
+                            "index": 0,
+                            "message": {
+                              "role": "assistant",
+                              "content": "Bonjour"
+                            },
+                            "finish_reason": "stop"
+                          }],
+                          "usage": {"prompt_tokens": 100, "completion_tokens": 10, "total_tokens": 110}
+                        }
+                        """)));
+
+            RunContext runContext = runContextFactory.of(Map.of());
+
+            var chat = ChatCompletion.builder()
+                .provider(
+                    OpenAI.builder()
+                        .type(OpenAI.class.getName())
+                        .apiKey(Property.ofValue("test-key"))
+                        .modelName(Property.ofValue("gpt-4o-mini"))
+                        .baseUrl(Property.ofValue(wireMock.baseUrl() + "/v1"))
+                        .build()
+                )
+                .tools(
+                    List.of(
+                        Skill.builder()
+                            .skills(
+                                List.of(
+                                    Skill.SkillDefinition.builder()
+                                        .name(Property.ofValue("translator"))
+                                        .description(Property.ofValue("Translates text"))
+                                        .content(Property.ofValue("Translate to the target language."))
+                                        .build()
+                                )
+                            )
+                            .build()
+                    )
+                )
+                .messages(
+                    Property.ofValue(
+                        List.of(
+                            ChatMessage.builder()
+                                .type(ChatMessageType.SYSTEM)
+                                .content("Always activate a skill before answering.")
+                                .build(),
+                            ChatMessage.builder()
+                                .type(ChatMessageType.USER)
+                                .content("Translate 'Hello' to French.")
+                                .build()
+                        )
+                    )
+                )
+                .configuration(ChatConfiguration.builder().temperature(Property.ofValue(0.1)).build())
+                .build();
+
+            var output = chat.run(runContext);
+            assertThat(output.getToolExecutions()).isNotEmpty();
+            assertThat(output.getToolExecutions()).extracting("requestName").contains("activate_skill");
+            assertThat(output.getTextOutput()).isEqualTo("Bonjour");
+            assertThat(output.getIntermediateResponses()).isNotEmpty();
+            assertThat(output.getIntermediateResponses().getFirst().getFinishReason()).isEqualTo(FinishReason.TOOL_EXECUTION);
+        } finally {
+            wireMock.stop();
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Adds a new `Skill` tool that exposes langchain4j skills as tools for AI agents
- Skills are structured instructions agents can activate on demand, with support for inline content, content URIs, and attached resources
- Includes unit test with WireMock verifying skill activation flow

## Test plan
- [x] Unit test `SkillTest.skillWithInlineContent` validates end-to-end skill activation

closes https://github.com/kestra-io/plugin-ai/issues/266