### PR TITLE
test: add GoogleVertexAI tests for ChatCompletion and Classification

### DIFF
--- a/src/test/java/io/kestra/plugin/ai/completion/ChatCompletionTest.java
+++ b/src/test/java/io/kestra/plugin/ai/completion/ChatCompletionTest.java
@@ -64,6 +64,8 @@ class ChatCompletionTest extends ContainerTest {
     private final String ZHIPU_API_KEY = System.getenv("ZHIPU_API_KEY");
     private final String WATSONX_API_KEY = System.getenv("WATSONX_API_KEY");
     private final String WATSONX_PROJECT_ID = System.getenv("WATSONX_PROJECT_ID");;
+    private final String VERTEX_AI_PROJECT = System.getenv("VERTEX_AI_PROJECT");
+    private final String VERTEX_AI_LOCATION = System.getenv("VERTEX_AI_LOCATION");
 
     @Inject
     private RunContextFactory runContextFactory;
@@ -290,6 +292,115 @@ class ChatCompletionTest extends ContainerTest {
 
         // Verify error message contains 404 details
         assertThat(exception.getMessage(), containsString("Unable to submit request because thinking is not supported by this model."));
+    }
+
+    /**
+     * Test Chat Completion using Google Vertex AI.
+     */
+    @Test
+    @EnabledIfEnvironmentVariable(named = "VERTEX_AI_PROJECT", matches = ".*")
+    @EnabledIfEnvironmentVariable(named = "VERTEX_AI_LOCATION", matches = ".*")
+    void testChatCompletionVertexAI() throws Exception {
+        RunContext runContext = runContextFactory.of(
+            Map.of(
+                "project", VERTEX_AI_PROJECT,
+                "location", VERTEX_AI_LOCATION,
+                "modelName", "gemini-2.0-flash",
+                "messages", List.of(
+                    ChatMessage.builder().type(ChatMessageType.USER).content("Hello, my name is John").build()
+                )
+            )
+        );
+
+        ChatCompletion task = ChatCompletion.builder()
+            .configuration(ChatConfiguration.builder().temperature(Property.ofValue(0.1)).seed(Property.ofValue(123456789)).build())
+            .messages(Property.ofExpression("{{ messages }}"))
+            .provider(
+                GoogleVertexAI.builder()
+                    .type(GoogleVertexAI.class.getName())
+                    .modelName(Property.ofExpression("{{ modelName }}"))
+                    .location(Property.ofExpression("{{ location }}"))
+                    .project(Property.ofExpression("{{ project }}"))
+                    .build()
+            )
+            .build();
+
+        ChatCompletion.Output output = task.run(runContext);
+
+        assertThat(output.getTextOutput(), notNullValue());
+        assertThat(output.getTextOutput(), containsString("John"));
+        assertThat(output.getRequestDuration(), notNullValue());
+        assertThat(output.getSources(), notNullValue());
+        assertTrue(output.getSources().isEmpty());
+    }
+
+    @Test
+    @EnabledIfEnvironmentVariable(named = "VERTEX_AI_PROJECT", matches = ".*")
+    @EnabledIfEnvironmentVariable(named = "VERTEX_AI_LOCATION", matches = ".*")
+    void testChatCompletionVertexAI_givenMaxTokenInput_shouldRespectMaxOutputTokens() throws Exception {
+        RunContext runContext = runContextFactory.of(
+            Map.of(
+                "project", VERTEX_AI_PROJECT,
+                "location", VERTEX_AI_LOCATION,
+                "modelName", "gemini-2.0-flash",
+                "messages", List.of(
+                    ChatMessage.builder().type(ChatMessageType.USER).content("Hello, my name is John").build()
+                )
+            )
+        );
+
+        ChatCompletion task = ChatCompletion.builder()
+            .configuration(
+                ChatConfiguration.builder().temperature(Property.ofValue(0.1)).seed(Property.ofValue(123456789))
+                    .maxToken(Property.ofValue(10)).build()
+            )
+            .messages(Property.ofExpression("{{ messages }}"))
+            .provider(
+                GoogleVertexAI.builder()
+                    .type(GoogleVertexAI.class.getName())
+                    .modelName(Property.ofExpression("{{ modelName }}"))
+                    .location(Property.ofExpression("{{ location }}"))
+                    .project(Property.ofExpression("{{ project }}"))
+                    .build()
+            )
+            .build();
+
+        ChatCompletion.Output output = task.run(runContext);
+
+        assertThat(output.getTextOutput(), notNullValue());
+        assertThat(output.getRequestDuration(), notNullValue());
+        assertThat(output.getTokenUsage().getOutputTokenCount(), equalTo(10));
+    }
+
+    @Test
+    void testChatCompletionVertexAI_givenEndpointSet_shouldThrowIllegalArgumentException() {
+        RunContext runContext = runContextFactory.of(
+            Map.of(
+                "project", "dummy-project",
+                "location", "us-central1",
+                "endpoint", "https://us-central1-aiplatform.googleapis.com",
+                "modelName", "gemini-2.0-flash",
+                "messages", List.of(
+                    ChatMessage.builder().type(ChatMessageType.USER).content("Hello").build()
+                )
+            )
+        );
+
+        ChatCompletion task = ChatCompletion.builder()
+            .configuration(ChatConfiguration.builder().build())
+            .messages(Property.ofExpression("{{ messages }}"))
+            .provider(
+                GoogleVertexAI.builder()
+                    .type(GoogleVertexAI.class.getName())
+                    .modelName(Property.ofExpression("{{ modelName }}"))
+                    .location(Property.ofExpression("{{ location }}"))
+                    .project(Property.ofExpression("{{ project }}"))
+                    .endpoint(Property.ofExpression("{{ endpoint }}"))
+                    .build()
+            )
+            .build();
+
+        assertThrows(IllegalArgumentException.class, () -> task.run(runContext));
     }
 
     /**

--- a/src/test/java/io/kestra/plugin/ai/completion/ClassificationTest.java
+++ b/src/test/java/io/kestra/plugin/ai/completion/ClassificationTest.java
@@ -15,6 +15,7 @@ import io.kestra.plugin.ai.ContainerTest;
 import io.kestra.plugin.ai.domain.GuardrailRule;
 import io.kestra.plugin.ai.domain.Guardrails;
 import io.kestra.plugin.ai.provider.GoogleGemini;
+import io.kestra.plugin.ai.provider.GoogleVertexAI;
 import io.kestra.plugin.ai.provider.Ollama;
 import io.kestra.plugin.ai.provider.OpenAI;
 import io.kestra.plugin.ai.provider.OpenRouter;
@@ -33,6 +34,8 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 class ClassificationTest extends ContainerTest {
     private final String GEMINI_API_KEY = System.getenv("GEMINI_API_KEY");
     private final String OPENROUTER_API_KEY = System.getenv("OPENROUTER_API_KEY");
+    private final String VERTEX_AI_PROJECT = System.getenv("VERTEX_AI_PROJECT");
+    private final String VERTEX_AI_LOCATION = System.getenv("VERTEX_AI_LOCATION");
 
     @Inject
     private RunContextFactory runContextFactory;
@@ -59,6 +62,42 @@ class ClassificationTest extends ContainerTest {
                     .type(GoogleGemini.class.getName())
                     .apiKey(Property.ofExpression("{{ apiKey }}"))
                     .modelName(Property.ofExpression("{{ modelName }}"))
+                    .build()
+            )
+            .build();
+
+        // WHEN
+        Classification.Output runOutput = task.run(runContext);
+
+        // THEN
+        assertThat(runOutput.getClassification(), notNullValue());
+    }
+
+    @Test
+    @EnabledIfEnvironmentVariable(named = "VERTEX_AI_PROJECT", matches = ".*")
+    @EnabledIfEnvironmentVariable(named = "VERTEX_AI_LOCATION", matches = ".*")
+    void testClassificationVertexAI() throws Exception {
+        // GIVEN
+        RunContext runContext = runContextFactory.of(
+            Map.of(
+                "prompt", "Is 'This is a joke' a good joke?",
+                "classes", List.of("true", "false"),
+                "project", VERTEX_AI_PROJECT,
+                "location", VERTEX_AI_LOCATION,
+                "modelName", "gemini-2.0-flash"
+            )
+        );
+
+        Classification task = Classification.builder()
+            .prompt(Property.ofExpression("{{ prompt }}"))
+            .systemMessage(Property.ofValue("You are a text classification assistant."))
+            .classes(Property.ofExpression("{{ classes }}"))
+            .provider(
+                GoogleVertexAI.builder()
+                    .type(GoogleVertexAI.class.getName())
+                    .modelName(Property.ofExpression("{{ modelName }}"))
+                    .location(Property.ofExpression("{{ location }}"))
+                    .project(Property.ofExpression("{{ project }}"))
                     .build()
             )
             .build();


### PR DESCRIPTION
## Summary

- Add `VERTEX_AI_PROJECT` and `VERTEX_AI_LOCATION` fields to `ChatCompletionTest` and `ClassificationTest`
- Add `testChatCompletionVertexAI` — happy path: verifies the model responds with the user's name
- Add `testChatCompletionVertexAI_givenMaxTokenInput_shouldRespectMaxOutputTokens` — verifies `maxToken` is respected (output token count capped at 10)
- Add `testChatCompletionVertexAI_givenEndpointSet_shouldThrowIllegalArgumentException` — local validation, no network call needed; asserts that setting `endpoint` on the chat provider throws `IllegalArgumentException`
- Add `testClassificationVertexAI` — happy path: verifies the model returns a non-null classification

All live tests are gated with `@EnabledIfEnvironmentVariable` on `VERTEX_AI_PROJECT` and `VERTEX_AI_LOCATION`. The exception test runs unconditionally since it validates local behavior.

## Test plan

- [ ] CI passes with `VERTEX_AI_PROJECT` and `VERTEX_AI_LOCATION` set: live Vertex AI tests run and pass
- [ ] CI passes without those env vars: gated tests are skipped, exception test still passes
- [ ] No regressions in existing tests

closes https://github.com/kestra-io/plugin-ai/issues/27