### PR TITLE
feat: add @PluginProperty group annotations

### DIFF
--- a/src/main/java/io/kestra/plugin/ai/agent/A2AClient.java
+++ b/src/main/java/io/kestra/plugin/ai/agent/A2AClient.java
@@ -12,6 +12,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import lombok.*;
 import lombok.experimental.SuperBuilder;
+import io.kestra.core.models.annotations.PluginProperty;
 
 @SuperBuilder
 @ToString
@@ -48,10 +49,12 @@ import lombok.experimental.SuperBuilder;
 public class A2AClient extends Task implements RunnableTask<A2AClient.Output> {
     @Schema(title = "Server URL", description = "The URL of the remote agent A2A server")
     @NotNull
+    @PluginProperty(group = "main")
     protected Property<String> serverUrl;
 
     @Schema(title = "Text prompt", description = "The input prompt for the language model")
     @NotNull
+    @PluginProperty(group = "main")
     protected Property<String> prompt;
 
     @Override

--- a/src/main/java/io/kestra/plugin/ai/agent/AIAgent.java
+++ b/src/main/java/io/kestra/plugin/ai/agent/AIAgent.java
@@ -677,39 +677,45 @@ import static io.kestra.core.utils.Rethrow.throwFunction;
 public class AIAgent extends Task implements RunnableTask<AIOutput>, OutputFilesInterface {
 
     @Schema(title = "System message", description = "The system message for the language model")
+    @PluginProperty(group = "advanced")
     protected Property<String> systemMessage;
 
     @Schema(title = "Text prompt", description = "The input prompt for the language model")
     @NotNull
+    @PluginProperty(group = "main")
     protected Property<String> prompt;
 
     @Schema(title = "Language model provider")
     @NotNull
-    @PluginProperty
+    @PluginProperty(group = "main")
     private ModelProvider provider;
 
     @Schema(title = "Language model configuration")
     @NotNull
-    @PluginProperty
+    @PluginProperty(group = "advanced")
     @Builder.Default
     private ChatConfiguration configuration = ChatConfiguration.empty();
 
     @Schema(title = "Tools that the LLM may use to augment its response")
+    @PluginProperty(group = "destination")
     private List<ToolProvider> tools;
 
     @Schema(title = "Maximum sequential tools invocations")
+    @PluginProperty(group = "execution")
     private Property<Integer> maxSequentialToolsInvocations;
 
     @Schema(
         title = "Content retrievers",
         description = "Some content retrievers, like WebSearch, can also be used as tools. However, when configured as content retrievers, they will always be used, whereas tools are only invoked when the LLM decides to use them."
     )
+    @PluginProperty(group = "advanced")
     private Property<List<ContentRetrieverProvider>> contentRetrievers;
 
     @Schema(
         title = "Agent memory",
         description = "Agent memory will store messages and add them as history to the LLM context."
     )
+    @PluginProperty(group = "execution")
     private MemoryProvider memory;
 
     @Schema(
@@ -730,6 +736,7 @@ public class AIAgent extends Task implements RunnableTask<AIOutput>, OutputFiles
     @PluginProperty
     private Guardrails guardrails;
 
+    @PluginProperty(group = "destination")
     private Property<List<String>> outputFiles;
 
     @Override

--- a/src/main/java/io/kestra/plugin/ai/completion/ChatCompletion.java
+++ b/src/main/java/io/kestra/plugin/ai/completion/ChatCompletion.java
@@ -239,21 +239,23 @@ public class ChatCompletion extends Task implements RunnableTask<ChatCompletion.
         description = "The list of chat messages for the current conversation. A `ChatMessage` can either be text (using `content`) or a multi-block multimodal message (using `contentBlocks`). There can be only one system message, and the last message must be a user message."
     )
     @NotNull
+    @PluginProperty(group = "main")
     protected Property<List<ChatMessage>> messages;
 
     @Schema(title = "Language Model Provider")
     @NotNull
-    @PluginProperty
+    @PluginProperty(group = "main")
     private ModelProvider provider;
 
     @Schema(title = "Chat configuration")
     @NotNull
-    @PluginProperty
+    @PluginProperty(group = "advanced")
     @Builder.Default
     private ChatConfiguration configuration = ChatConfiguration.empty();
 
     @Schema(title = "Tools that the LLM may use to augment its response")
     @Nullable
+    @PluginProperty(group = "destination")
     private List<ToolProvider> tools;
 
     @Schema(

--- a/src/main/java/io/kestra/plugin/ai/completion/Classification.java
+++ b/src/main/java/io/kestra/plugin/ai/completion/Classification.java
@@ -99,6 +99,7 @@ public class Classification extends Task implements RunnableTask<Classification.
 
     @Schema(title = "Text prompt", description = "Text input to classify. Use either `prompt` or `contentBlocks`.")
     @Nullable
+    @PluginProperty(group = "main")
     private Property<String> prompt;
 
     @Schema(
@@ -113,22 +114,24 @@ public class Classification extends Task implements RunnableTask<Classification.
         description = "Instruction message for the model. Defaults to a standard classification instruction using the provided classes."
     )
     @Builder.Default
+    @PluginProperty(group = "advanced")
     private Property<String> systemMessage = Property.ofExpression(
         "Respond by only one of the following classes by typing just the exact class name: {{ classes }}"
     );
 
     @Schema(title = "Classification Options", description = "The list of possible classification categories")
     @NotNull
+    @PluginProperty(group = "main")
     private Property<List<String>> classes;
 
     @Schema(title = "Language Model Provider")
     @NotNull
-    @PluginProperty
+    @PluginProperty(group = "main")
     private ModelProvider provider;
 
     @Schema(title = "Chat configuration")
     @NotNull
-    @PluginProperty
+    @PluginProperty(group = "advanced")
     @Builder.Default
     private ChatConfiguration configuration = ChatConfiguration.empty();
 

--- a/src/main/java/io/kestra/plugin/ai/completion/ImageGeneration.java
+++ b/src/main/java/io/kestra/plugin/ai/completion/ImageGeneration.java
@@ -91,11 +91,12 @@ public class ImageGeneration extends Task implements RunnableTask<ImageGeneratio
 
     @Schema(title = "Image prompt", description = "The input prompt for the image generation model")
     @NotNull
+    @PluginProperty(group = "main")
     private Property<String> prompt;
 
     @Schema(title = "Language Model Provider")
     @NotNull
-    @PluginProperty
+    @PluginProperty(group = "main")
     private ModelProvider provider;
 
     @Override

--- a/src/main/java/io/kestra/plugin/ai/completion/JSONStructuredExtraction.java
+++ b/src/main/java/io/kestra/plugin/ai/completion/JSONStructuredExtraction.java
@@ -150,6 +150,7 @@ public class JSONStructuredExtraction extends Task implements RunnableTask<JSONS
 
     @Schema(title = "Text prompt", description = "Text input for structured JSON extraction. Use either `prompt` or `contentBlocks`.")
     @Nullable
+    @PluginProperty(group = "main")
     private Property<String> prompt;
 
     @Schema(
@@ -161,26 +162,29 @@ public class JSONStructuredExtraction extends Task implements RunnableTask<JSONS
 
     @Schema(title = "System message", description = "Optional system instruction for the model.")
     @Builder.Default
+    @PluginProperty(group = "advanced")
     private Property<String> systemMessage = Property.ofValue(
         "You are a structured JSON extraction assistant. Always respond with valid JSON."
     );
 
     @Schema(title = "Schema Name", description = "The name of the JSON schema for structured extraction")
     @NotNull
+    @PluginProperty(group = "main")
     private Property<String> schemaName;
 
     @Schema(title = "JSON Fields", description = "List of fields to extract from the text")
     @NotNull
+    @PluginProperty(group = "main")
     private Property<List<String>> jsonFields;
 
     @Schema(title = "Language Model Provider")
     @NotNull
-    @PluginProperty
+    @PluginProperty(group = "main")
     private ModelProvider provider;
 
     @Schema(title = "Chat configuration")
     @NotNull
-    @PluginProperty
+    @PluginProperty(group = "advanced")
     @Builder.Default
     private ChatConfiguration configuration = ChatConfiguration.empty();
 

--- a/src/main/java/io/kestra/plugin/ai/domain/AIOutput.java
+++ b/src/main/java/io/kestra/plugin/ai/domain/AIOutput.java
@@ -38,31 +38,38 @@ public class AIOutput implements io.kestra.core.models.tasks.Output {
         title = "LLM output for `TEXT` response format",
         description = "The result of the LLM completion for response format of type `TEXT` (default), null otherwise."
     )
+    @PluginProperty(group = "destination")
     private String textOutput;
 
     @Schema(
         title = "LLM output for `JSON` response format",
         description = "The result of the LLM completion for response format of type `JSON`, null otherwise."
     )
+    @PluginProperty(group = "destination")
     private Map<String, Object> jsonOutput;
 
     @Schema(title = "Token usage")
+    @PluginProperty(group = "advanced")
     private TokenUsage tokenUsage;
 
     @Schema(title = "Finish reason")
+    @PluginProperty(group = "advanced")
     private FinishReason finishReason;
 
     @Schema(title = "Tool executions")
+    @PluginProperty(group = "advanced")
     private List<ToolExecution> toolExecutions;
 
     @Schema(title = "Intermediate responses")
+    @PluginProperty(group = "advanced")
     private List<AIResponse> intermediateResponses;
 
     @Schema(title = "Request duration in milliseconds")
+    @PluginProperty(group = "execution")
     private Long requestDuration;
 
     @Schema(title = "URIs of the generated files in Kestra's internal storage")
-    @PluginProperty(additionalProperties = URI.class)
+    @PluginProperty(additionalProperties = URI.class, group = "destination")
     private final Map<String, URI> outputFiles;
 
     @Schema(
@@ -71,9 +78,11 @@ public class AIOutput implements io.kestra.core.models.tasks.Output {
             Contains the model's internal reasoning or 'thinking' text, if the model supports it and 'returnThinking' is enabled.
             This may include intermediate reasoning steps, such as chain-of-thought explanations. Null if thinking is not supported, not enabled, or not returned by the model."""
     )
+    @PluginProperty(group = "advanced")
     private final String thinking;
 
     @Schema(title = "Content sources used during RAG retrieval")
+    @PluginProperty(group = "advanced")
     private final List<ContentSource> sources;
 
     @Schema(
@@ -81,12 +90,14 @@ public class AIOutput implements io.kestra.core.models.tasks.Output {
         description = "True when an input or output guardrail expression evaluated to false. When true, `guardrailViolationMessage` contains the rule's configured message and no LLM output is available."
     )
     @Builder.Default
+    @PluginProperty(group = "advanced")
     private final boolean guardrailViolated = false;
 
     @Schema(
         title = "Guardrail violation message",
         description = "The message from the first guardrail rule that failed. Null when no guardrail was violated."
     )
+    @PluginProperty(group = "advanced")
     private final String guardrailViolationMessage;
 
     // WARNING: When adding additional properties here, don't forget to update completion and rag ChatCompletion.Output
@@ -159,12 +170,14 @@ public class AIOutput implements io.kestra.core.models.tasks.Output {
             title = "Extracted text segment",
             description = "A snippet of text relevant to the user's query, typically a sentence, paragraph, or other discrete unit of text."
         )
+        @PluginProperty(group = "advanced")
         private String content;
 
         @Schema(
             title = "Source metadata",
             description = "Key-value pairs providing context about the origin of the content, such as URLs, document titles, or other relevant attributes."
         )
+        @PluginProperty(group = "advanced")
         private Map<String, Object> metadata;
 
         public static ContentSource from(Content content) {
@@ -184,21 +197,27 @@ public class AIOutput implements io.kestra.core.models.tasks.Output {
     @Builder
     public static class AIResponse {
         @Schema(title = "Response identifier")
+        @PluginProperty(group = "advanced")
         private String id;
 
         @Schema(title = "Generated text completion", description = "The result of the text completion")
+        @PluginProperty(group = "advanced")
         private String completion;
 
         @Schema(title = "Token usage")
+        @PluginProperty(group = "advanced")
         private TokenUsage tokenUsage;
 
         @Schema(title = "Finish reason")
+        @PluginProperty(group = "advanced")
         private FinishReason finishReason;
 
         @Schema(title = "Tool execution requests")
+        @PluginProperty(group = "advanced")
         private List<ToolExecutionRequest> toolExecutionRequests;
 
         @Schema(title = "Request duration in milliseconds")
+        @PluginProperty(group = "execution")
         private Long requestDuration;
 
         static AIResponse from(RunContext runContext, ChatResponse chatResponse) throws JsonProcessingException {
@@ -220,12 +239,15 @@ public class AIOutput implements io.kestra.core.models.tasks.Output {
         @Builder
         public static class ToolExecutionRequest {
             @Schema(title = "Tool execution request identifier")
+            @PluginProperty(group = "advanced")
             private String id;
 
             @Schema(title = "Tool name")
+            @PluginProperty(group = "advanced")
             private String name;
 
             @Schema(title = "Tool request arguments")
+            @PluginProperty(group = "advanced")
             private Map<String, Object> arguments;
 
             static ToolExecutionRequest from(dev.langchain4j.agent.tool.ToolExecutionRequest toolExecutionRequest) throws JsonProcessingException {

--- a/src/main/java/io/kestra/plugin/ai/domain/ChatConfiguration.java
+++ b/src/main/java/io/kestra/plugin/ai/domain/ChatConfiguration.java
@@ -15,6 +15,7 @@ import jakarta.annotation.Nullable;
 import jakarta.validation.constraints.NotNull;
 import lombok.Builder;
 import lombok.Getter;
+import io.kestra.core.models.annotations.PluginProperty;
 
 @Getter
 @Builder
@@ -23,36 +24,42 @@ public class ChatConfiguration {
         title = "Temperature",
         description = "Controls randomness in generation. Typical range is 0.0–1.0. Lower values (e.g., 0.2) make outputs more focused and deterministic, while higher values (e.g., 0.7–1.0) increase creativity and variability."
     )
+    @PluginProperty(group = "advanced")
     private Property<Double> temperature;
 
     @Schema(
         title = "Top-K",
         description = "Limits sampling to the top K most likely tokens at each step. Typical values are between 20 and 100. Smaller values reduce randomness; larger values allow more diverse outputs."
     )
+    @PluginProperty(group = "advanced")
     private Property<Integer> topK;
 
     @Schema(
         title = "Top-P (nucleus sampling)",
         description = "Selects from the smallest set of tokens whose cumulative probability is ≤ topP. Typical values are 0.8–0.95. Lower values make the output more focused, higher values increase diversity."
     )
+    @PluginProperty(group = "advanced")
     private Property<Double> topP;
 
     @Schema(
         title = "Seed",
         description = "Optional random seed for reproducibility. Provide a positive integer (e.g., 42, 1234). Using the same seed with identical settings produces repeatable outputs."
     )
+    @PluginProperty(group = "advanced")
     private Property<Integer> seed;
 
     @Schema(
         title = "Log LLM requests",
         description = "If true, prompts and configuration sent to the LLM will be logged at INFO level."
     )
+    @PluginProperty(group = "advanced")
     private Property<Boolean> logRequests;
 
     @Schema(
         title = "Log LLM responses",
         description = "If true, raw responses from the LLM will be logged at INFO level."
     )
+    @PluginProperty(group = "advanced")
     private Property<Boolean> logResponses;
 
     @Schema(
@@ -62,6 +69,7 @@ public class ChatConfiguration {
             Some providers allow requesting JSON or schema-constrained outputs, but support varies and may be incompatible with tool use.
             When using a JSON schema, the output will be returned under the key `jsonOutput`."""
     )
+    @PluginProperty(group = "processing")
     private ResponseFormat responseFormat;
 
     @Schema(
@@ -71,6 +79,7 @@ public class ChatConfiguration {
             before producing a final output; this is useful for complex tasks like multi-step problem solving or decision making, but may
             increase token usage and response time, and is only applicable to compatible models."""
     )
+    @PluginProperty(group = "advanced")
     private Property<Boolean> thinkingEnabled;
 
     @Schema(
@@ -79,6 +88,7 @@ public class ChatConfiguration {
             Specifies the maximum number of tokens allocated as a budget for internal reasoning processes, such as generating intermediate
             thoughts or chain-of-thought sequences, allowing the model to perform multi-step reasoning before producing the final output."""
     )
+    @PluginProperty(group = "advanced")
     private Property<Integer> thinkingBudgetTokens;
 
     @Schema(
@@ -88,6 +98,7 @@ public class ChatConfiguration {
             the reasoning content is extracted from the response and made available in the AiMessage object.
             It Does not trigger the thinking process itself—only affects whether the output is parsed and returned."""
     )
+    @PluginProperty(group = "advanced")
     private Property<Boolean> returnThinking;
 
     @Schema(
@@ -95,6 +106,7 @@ public class ChatConfiguration {
         example = "1024"
     )
     @Nullable
+    @PluginProperty(group = "connection")
     private Property<Integer> maxToken;
 
     @Schema(
@@ -104,6 +116,7 @@ public class ChatConfiguration {
             This can significantly reduce latency and cost for repeated calls with the same system prompt or tools.
             Currently supported by Anthropic only; other providers silently ignore this setting."""
     )
+    @PluginProperty(group = "advanced")
     private Property<Boolean> promptCaching;
 
     public dev.langchain4j.model.chat.request.ResponseFormat computeResponseFormat(RunContext runContext) throws IllegalVariableEvaluationException {
@@ -140,6 +153,7 @@ public class ChatConfiguration {
         )
         @NotNull
         @Builder.Default
+        @PluginProperty(group = "main")
         private Property<ResponseFormatType> type = Property.ofValue(ResponseFormatType.TEXT);
 
         @Schema(
@@ -166,6 +180,7 @@ public class ChatConfiguration {
                 guide the model about the expected output structure via the prompt and validate downstream.
                 """
         )
+        @PluginProperty(group = "connection")
         private Property<Map<String, Object>> jsonSchema;
 
         @Schema(
@@ -175,6 +190,7 @@ public class ChatConfiguration {
                 Example: "Classify a customer ticket into category and priority."
                 """
         )
+        @PluginProperty(group = "advanced")
         private Property<String> jsonSchemaDescription;
 
         @Schema(
@@ -182,6 +198,7 @@ public class ChatConfiguration {
             description = "When true, providers that support it enforce strict JSON schema output when `type` is `JSON`."
         )
         @Builder.Default
+        @PluginProperty(group = "advanced")
         private Property<Boolean> strictJson = Property.ofValue(false);
 
         dev.langchain4j.model.chat.request.ResponseFormat to(RunContext runContext) throws IllegalVariableEvaluationException {

--- a/src/main/java/io/kestra/plugin/ai/domain/GuardrailRule.java
+++ b/src/main/java/io/kestra/plugin/ai/domain/GuardrailRule.java
@@ -5,6 +5,7 @@ import jakarta.validation.constraints.NotBlank;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.extern.jackson.Jacksonized;
+import io.kestra.core.models.annotations.PluginProperty;
 
 @Getter
 @Builder
@@ -24,6 +25,7 @@ public class GuardrailRule {
             """
     )
     @NotBlank
+    @PluginProperty(group = "advanced")
     private String expression;
 
     @Schema(
@@ -31,5 +33,6 @@ public class GuardrailRule {
         description = "The message returned when the expression evaluates to `false`."
     )
     @NotBlank
+    @PluginProperty(group = "advanced")
     private String message;
 }

--- a/src/main/java/io/kestra/plugin/ai/domain/Guardrails.java
+++ b/src/main/java/io/kestra/plugin/ai/domain/Guardrails.java
@@ -6,6 +6,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.extern.jackson.Jacksonized;
+import io.kestra.core.models.annotations.PluginProperty;
 
 @Getter
 @Builder
@@ -19,6 +20,7 @@ public class Guardrails {
             Each rule's Pebble expression has access to the `message` variable (the user message text).
             The first failing rule halts execution and returns a guardrail violation in the task output."""
     )
+    @PluginProperty(group = "advanced")
     private List<GuardrailRule> input;
 
     @Schema(
@@ -29,5 +31,6 @@ public class Guardrails {
             `finishReason`, `inputTokenCount`, and `outputTokenCount`.
             The first failing rule halts and returns a guardrail violation in the task output."""
     )
+    @PluginProperty(group = "advanced")
     private List<GuardrailRule> output;
 }

--- a/src/main/java/io/kestra/plugin/ai/domain/LangfuseObservability.java
+++ b/src/main/java/io/kestra/plugin/ai/domain/LangfuseObservability.java
@@ -8,6 +8,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
+import io.kestra.core.models.annotations.PluginProperty;
 
 @Getter
 @SuperBuilder(toBuilder = true)
@@ -23,11 +24,14 @@ public class LangfuseObservability extends Observability {
         title = "Langfuse OTLP endpoint",
         description = "Langfuse OTLP endpoint (for example: https://us.cloud.langfuse.com/api/public/otel)."
     )
+    @PluginProperty(group = "connection")
     private Property<String> endpoint;
 
     @Schema(title = "Langfuse public key")
+    @PluginProperty(group = "connection")
     private Property<String> publicKey;
 
     @Schema(title = "Langfuse secret key")
+    @PluginProperty(group = "connection")
     private Property<String> secretKey;
 }

--- a/src/main/java/io/kestra/plugin/ai/domain/MemoryProvider.java
+++ b/src/main/java/io/kestra/plugin/ai/domain/MemoryProvider.java
@@ -18,6 +18,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
+import io.kestra.core.models.annotations.PluginProperty;
 
 @Plugin
 @SuperBuilder(toBuilder = true)
@@ -29,14 +30,17 @@ import lombok.experimental.SuperBuilder;
 public abstract class MemoryProvider extends AdditionalPlugin {
     @Schema(title = "Maximum number of messages to keep in memory. If memory is full, the oldest messages will be removed in a FIFO manner. The last system message is always kept.")
     @Builder.Default
+    @PluginProperty(group = "advanced")
     private Property<Integer> messages = Property.ofValue(10);
 
     @Schema(title = "Memory duration - defaults to 1h")
     @Builder.Default
+    @PluginProperty(group = "advanced")
     private Property<Duration> ttl = Property.ofValue(Duration.ofHours(1));
 
     @Schema(title = "Memory ID - defaults to the value of the `system.correlationId` label. This means that a memory is valid for the entire flow execution including its subflows.")
     @Builder.Default
+    @PluginProperty(group = "advanced")
     private Property<String> memoryId = Property.ofExpression("{{ labels.system.correlationId }}");
 
     @Schema(
@@ -47,6 +51,7 @@ public abstract class MemoryProvider extends AdditionalPlugin {
             You can also set `drop: BEFORE_TASKRUN` to drop the memory before the taskrun."""
     )
     @Builder.Default
+    @PluginProperty(group = "advanced")
     private Property<Drop> drop = Property.ofValue(Drop.NEVER);
 
     public abstract ChatMemory chatMemory(RunContext runContext) throws IllegalVariableEvaluationException, IOException;

--- a/src/main/java/io/kestra/plugin/ai/domain/ModelProvider.java
+++ b/src/main/java/io/kestra/plugin/ai/domain/ModelProvider.java
@@ -45,6 +45,7 @@ import lombok.experimental.SuperBuilder;
 
 import java.util.Collections;
 import java.util.List;
+import io.kestra.core.models.annotations.PluginProperty;
 
 @Plugin
 @SuperBuilder(toBuilder = true)
@@ -56,24 +57,28 @@ import java.util.List;
 public abstract class ModelProvider extends AdditionalPlugin {
     @Schema(title = "Model name")
     @NotNull
+    @PluginProperty(group = "main")
     private Property<String> modelName;
 
     @Schema(
         title = "Base URL",
         description = "Custom base URL to override the default endpoint (useful for local tests, WireMock, or enterprise gateways)."
     )
+    @PluginProperty(group = "connection")
     protected Property<String> baseUrl;
 
     @Schema(
         title = "Client PEM certificate content",
         description = "PEM client certificate as text, used to authenticate the connection to enterprise AI endpoints."
     )
+    @PluginProperty(group = "advanced")
     private Property<String> clientPem;
 
     @Schema(
         title = "CA PEM certificate content",
         description = "CA certificate as text, used to verify SSL/TLS connections when using custom endpoints."
     )
+    @PluginProperty(group = "advanced")
     private Property<String> caPem;
 
     public abstract ChatModel chatModel(RunContext runContext, ChatConfiguration configuration) throws IllegalVariableEvaluationException;

--- a/src/main/java/io/kestra/plugin/ai/domain/Observability.java
+++ b/src/main/java/io/kestra/plugin/ai/domain/Observability.java
@@ -13,6 +13,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
+import io.kestra.core.models.annotations.PluginProperty;
 
 @Plugin
 @SuperBuilder(toBuilder = true)
@@ -27,50 +28,60 @@ import lombok.experimental.SuperBuilder;
 )
 public abstract class Observability extends AdditionalPlugin {
     @Schema(title = "Service name")
+    @PluginProperty(group = "advanced")
     protected Property<String> serviceName;
 
     @Schema(title = "Environment")
+    @PluginProperty(group = "advanced")
     protected Property<String> environment;
 
     @Schema(title = "Release")
+    @PluginProperty(group = "advanced")
     protected Property<String> release;
 
     @Schema(
         title = "Capture prompt",
         description = "If true, prompt content is sent to the observability provider under input attributes. Disabled by default."
     )
+    @PluginProperty(group = "advanced")
     protected Property<Boolean> capturePrompt;
 
     @Schema(
         title = "Capture system message",
         description = "If true, system message content is sent in metadata. Disabled by default."
     )
+    @PluginProperty(group = "advanced")
     protected Property<Boolean> captureSystemMessage;
 
     @Schema(
         title = "Capture output",
         description = "If true, model output content is sent to the observability provider under output attributes. Disabled by default."
     )
+    @PluginProperty(group = "destination")
     protected Property<Boolean> captureOutput;
 
     @Schema(
         title = "Capture tool arguments",
         description = "If true, tool arguments are sent in tool execution events. Disabled by default."
     )
+    @PluginProperty(group = "advanced")
     protected Property<Boolean> captureToolArguments;
 
     @Schema(
         title = "Capture tool results",
         description = "If true, tool results are sent in tool execution events. Disabled by default."
     )
+    @PluginProperty(group = "advanced")
     protected Property<Boolean> captureToolResults;
 
     @Schema(
         title = "Maximum payload characters",
         description = "Maximum number of characters sent for any captured payload field. Longer values are truncated."
     )
+    @PluginProperty(group = "execution")
     protected Property<Integer> maxPayloadChars;
 
     @Schema(title = "Export timeout", description = "Timeout used for forceFlush and shutdown operations.")
+    @PluginProperty(group = "execution")
     protected Property<Duration> exportTimeout;
 }

--- a/src/main/java/io/kestra/plugin/ai/embeddings/Chroma.java
+++ b/src/main/java/io/kestra/plugin/ai/embeddings/Chroma.java
@@ -17,6 +17,7 @@ import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
+import io.kestra.core.models.annotations.PluginProperty;
 
 @Getter
 @SuperBuilder
@@ -57,10 +58,12 @@ public class Chroma extends EmbeddingStoreProvider {
 
     @NotNull
     @Schema(title = "The database base URL")
+    @PluginProperty(group = "main")
     private Property<String> baseUrl;
 
     @NotNull
     @Schema(title = "The collection name")
+    @PluginProperty(group = "main")
     private Property<String> collectionName;
 
     @Override

--- a/src/main/java/io/kestra/plugin/ai/embeddings/Elasticsearch.java
+++ b/src/main/java/io/kestra/plugin/ai/embeddings/Elasticsearch.java
@@ -95,6 +95,7 @@ public class Elasticsearch extends EmbeddingStoreProvider {
 
     @NotNull
     @Schema(title = "The name of the index to store embeddings")
+    @PluginProperty(group = "main")
     private Property<String> indexName;
 
     @Override
@@ -130,36 +131,40 @@ public class Elasticsearch extends EmbeddingStoreProvider {
             title = "List of HTTP Elasticsearch servers",
             description = "Must be a URI like `https://example.com:9200` with scheme and port"
         )
-        @PluginProperty(dynamic = true)
+        @PluginProperty(dynamic = true, group = "main")
         @NotNull
         @NotEmpty
         private List<String> hosts;
 
         @Schema(title = "Basic authorization configuration")
-        @PluginProperty
+        @PluginProperty(group = "advanced")
         private BasicAuth basicAuth;
 
         @Schema(
             title = "List of HTTP headers to be sent with every request",
             description = "Each item is a `key: value` string, e.g., `Authorization: Token XYZ`"
         )
+        @PluginProperty(group = "advanced")
         private Property<List<String>> headers;
 
         @Schema(
             title = "Path prefix for all HTTP requests",
             description = "If set to `/my/path`, each client request becomes `/my/path/` + endpoint. Useful when Elasticsearch is behind a proxy providing a base path; do not use otherwise."
         )
+        @PluginProperty(group = "advanced")
         private Property<String> pathPrefix;
 
         @Schema(
             title = "Treat responses with deprecation warnings as failures"
         )
+        @PluginProperty(group = "advanced")
         private Property<Boolean> strictDeprecationMode;
 
         @Schema(
             title = "Trust all SSL CA certificates",
             description = "Use this if the server uses a self-signed SSL certificate"
         )
+        @PluginProperty(group = "advanced")
         private Property<Boolean> trustAllSsl;
 
         @SuperBuilder
@@ -167,9 +172,11 @@ public class Elasticsearch extends EmbeddingStoreProvider {
         @Getter
         public static class BasicAuth {
             @Schema(title = "Basic authorization username")
+            @PluginProperty(group = "connection")
             private Property<String> username;
 
             @Schema(title = "Basic authorization password")
+            @PluginProperty(group = "connection")
             private Property<String> password;
         }
 

--- a/src/main/java/io/kestra/plugin/ai/embeddings/KestraKVStore.java
+++ b/src/main/java/io/kestra/plugin/ai/embeddings/KestraKVStore.java
@@ -27,6 +27,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
+import io.kestra.core.models.annotations.PluginProperty;
 
 @Getter
 @SuperBuilder
@@ -68,6 +69,7 @@ public class KestraKVStore extends EmbeddingStoreProvider {
 
     @Schema(title = "The name of the KV pair to use")
     @Builder.Default
+    @PluginProperty(group = "advanced")
     private Property<String> kvName = Property.ofExpression("{{ flow.id }}-embedding-store");
 
     @Override

--- a/src/main/java/io/kestra/plugin/ai/embeddings/MariaDB.java
+++ b/src/main/java/io/kestra/plugin/ai/embeddings/MariaDB.java
@@ -26,6 +26,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
+import io.kestra.core.models.annotations.PluginProperty;
 
 @Getter
 @SuperBuilder
@@ -68,24 +69,30 @@ public class MariaDB extends EmbeddingStoreProvider {
 
     @NotNull
     @Schema(title = "The username")
+    @PluginProperty(group = "main")
     private Property<String> username;
     @NotNull
     @Schema(title = "The password")
+    @PluginProperty(group = "main")
     private Property<String> password;
 
     @NotNull
     @Schema(title = "Database URL of the MariaDB database (e.g., jdbc:mariadb://host:port/dbname)")
+    @PluginProperty(group = "main")
     private Property<String> databaseUrl;
     @NotNull
     @Schema(title = "Whether to create the table if it doesn't exist")
+    @PluginProperty(group = "main")
     private Property<Boolean> createTable;
 
     @NotNull
     @Schema(title = "Name of the table where embeddings will be stored")
+    @PluginProperty(group = "main")
     private Property<String> tableName;
 
     @NotNull
     @Schema(title = "Name of the column used as the unique ID in the database")
+    @PluginProperty(group = "main")
     private Property<String> fieldName;
 
     @Schema(
@@ -95,6 +102,7 @@ public class MariaDB extends EmbeddingStoreProvider {
               Required only when using COLUMN_PER_KEY storage mode.
             """
     )
+    @PluginProperty(group = "advanced")
     private Property<List<String>> columnDefinitions;
 
     @Schema(
@@ -104,6 +112,7 @@ public class MariaDB extends EmbeddingStoreProvider {
              Used only with COLUMN_PER_KEY storage mode.
             """
     )
+    @PluginProperty(group = "advanced")
     private Property<List<String>> indexes;
 
     @Schema(
@@ -116,6 +125,7 @@ public class MariaDB extends EmbeddingStoreProvider {
             """
     )
     @Builder.Default
+    @PluginProperty(group = "advanced")
     private Property<String> metadataStorageMode = Property.ofValue(MetadataStorageMode.COLUMN_PER_KEY.name());
 
     @Override

--- a/src/main/java/io/kestra/plugin/ai/embeddings/Milvus.java
+++ b/src/main/java/io/kestra/plugin/ai/embeddings/Milvus.java
@@ -22,6 +22,7 @@ import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
+import io.kestra.core.models.annotations.PluginProperty;
 
 @Getter
 @SuperBuilder
@@ -69,6 +70,7 @@ public class Milvus extends EmbeddingStoreProvider {
         description = "Milvus auth token. Required if authentication is enabled; omit for local deployments without auth."
     )
     @NotNull
+    @PluginProperty(group = "main")
     private Property<String> token;
 
     @Schema(
@@ -80,102 +82,119 @@ public class Milvus extends EmbeddingStoreProvider {
             - HTTP: "http://host:9091"
             """
     )
+    @PluginProperty(group = "advanced")
     private Property<String> uri;
 
     @Schema(
         title = "Host",
         description = "Milvus host name (used when `uri` is not set). Default: \"localhost\"."
     )
+    @PluginProperty(group = "connection")
     private Property<String> host;
 
     @Schema(
         title = "Port",
         description = "Milvus port (used when `uri` is not set). Typical: 19530 (gRPC) or 9091 (HTTP). Default: 19530."
     )
+    @PluginProperty(group = "connection")
     private Property<Integer> port;
 
     @Schema(
         title = "Username",
         description = "Required when authentication/TLS is enabled. See https://milvus.io/docs/authenticate.md"
     )
+    @PluginProperty(group = "connection")
     private Property<String> username;
 
     @Schema(
         title = "Password",
         description = "Required when authentication/TLS is enabled. See https://milvus.io/docs/authenticate.md"
     )
+    @PluginProperty(group = "connection")
     private Property<String> password;
 
     @Schema(
         title = "Collection name",
         description = "Target collection. Created automatically if it does not exist. Default: \"default\"."
     )
+    @PluginProperty(group = "advanced")
     private Property<String> collectionName;
 
     @Schema(
         title = "Consistency level",
         description = "Read/write consistency level. Common values include STRONG, BOUNDED, or EVENTUALLY (depends on client/version)."
     )
+    @PluginProperty(group = "advanced")
     private Property<String> consistencyLevel;
 
     @Schema(
         title = "Index type",
         description = "Vector index type (e.g., IVF_FLAT, IVF_SQ8, HNSW). Depends on Milvus deployment and dataset."
     )
+    @PluginProperty(group = "advanced")
     private Property<String> indexType;
 
     @Schema(
         title = "Metric type",
         description = "Similarity metric (e.g., L2, IP, COSINE). Should match the embedding provider’s expected metric."
     )
+    @PluginProperty(group = "advanced")
     private Property<String> metricType;
 
     @Schema(
         title = "Retrieve embeddings on search",
         description = "If true, return stored embeddings along with matches. Default: false."
     )
+    @PluginProperty(group = "advanced")
     private Property<Boolean> retrieveEmbeddingsOnSearch;
 
     @Schema(
         title = "Database name",
         description = "Logical database to use. If not provided, the default database is used."
     )
+    @PluginProperty(group = "advanced")
     private Property<String> databaseName;
 
     @Schema(
         title = "Auto flush on insert",
         description = "If true, flush after insert operations. Setting it to false can improve throughput."
     )
+    @PluginProperty(group = "advanced")
     private Property<Boolean> autoFlushOnInsert;
 
     @Schema(
         title = "Auto flush on delete",
         description = "If true, flush after delete operations."
     )
+    @PluginProperty(group = "advanced")
     private Property<Boolean> autoFlushOnDelete;
 
     @Schema(
         title = "ID field name",
         description = "Field name for document IDs. Default depends on collection schema."
     )
+    @PluginProperty(group = "advanced")
     private Property<String> idFieldName;
 
     @Schema(
         title = "Text field name",
         description = "Field name for original text. Default depends on collection schema."
     )
+    @PluginProperty(group = "advanced")
     private Property<String> textFieldName;
 
     @Schema(
         title = "Metadata field name",
         description = "Field name for metadata. Default depends on collection schema."
     )
+    @PluginProperty(group = "advanced")
     private Property<String> metadataFieldName;
 
     @Schema(
         title = "Vector field name",
         description = "Field name for the embedding vector. Must match the index definition and embedding dimensionality."
     )
+    @PluginProperty(group = "advanced")
     private Property<String> vectorFieldName;
 
     @Override

--- a/src/main/java/io/kestra/plugin/ai/embeddings/MongoDBAtlas.java
+++ b/src/main/java/io/kestra/plugin/ai/embeddings/MongoDBAtlas.java
@@ -31,6 +31,7 @@ import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
+import io.kestra.core.models.annotations.PluginProperty;
 
 @Getter
 @SuperBuilder
@@ -74,37 +75,47 @@ import lombok.experimental.SuperBuilder;
 public class MongoDBAtlas extends EmbeddingStoreProvider {
 
     @Schema(title = "The username")
+    @PluginProperty(group = "connection")
     private Property<String> username;
 
     @Schema(title = "The password")
+    @PluginProperty(group = "connection")
     private Property<String> password;
 
     @NotNull
     @Schema(title = "The scheme (e.g., mongodb+srv)")
+    @PluginProperty(group = "main")
     private Property<String> scheme;
 
     @NotNull
     @Schema(title = "The host")
+    @PluginProperty(group = "main")
     private Property<String> host;
 
     @Schema(title = "The database")
+    @PluginProperty(group = "connection")
     private Property<String> database;
 
     @Schema(title = "The connection string options")
+    @PluginProperty(group = "advanced")
     private Property<Map<String, Object>> options;
 
     @NotNull
     @Schema(title = "The collection name")
+    @PluginProperty(group = "main")
     private Property<String> collectionName;
 
     @NotNull
     @Schema(title = "The index name")
+    @PluginProperty(group = "main")
     private Property<String> indexName;
 
     @Schema(title = "The metadata field names")
+    @PluginProperty(group = "advanced")
     private Property<List<String>> metadataFieldNames;
 
     @Schema(title = "Create the index")
+    @PluginProperty(group = "advanced")
     private Property<Boolean> createIndex;
 
     @Override

--- a/src/main/java/io/kestra/plugin/ai/embeddings/PGVector.java
+++ b/src/main/java/io/kestra/plugin/ai/embeddings/PGVector.java
@@ -18,6 +18,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
+import io.kestra.core.models.annotations.PluginProperty;
 
 @Getter
 @SuperBuilder
@@ -61,26 +62,32 @@ import lombok.experimental.SuperBuilder;
 public class PGVector extends EmbeddingStoreProvider {
     @NotNull
     @Schema(title = "The database server host")
+    @PluginProperty(group = "main")
     private Property<String> host;
 
     @NotNull
     @Schema(title = "The database server port")
+    @PluginProperty(group = "main")
     private Property<Integer> port;
 
     @NotNull
     @Schema(title = "The database user")
+    @PluginProperty(group = "main")
     private Property<String> user;
 
     @NotNull
     @Schema(title = "The database password")
+    @PluginProperty(group = "main")
     private Property<String> password;
 
     @NotNull
     @Schema(title = "The database name")
+    @PluginProperty(group = "main")
     private Property<String> database;
 
     @NotNull
     @Schema(title = "The table to store embeddings in")
+    @PluginProperty(group = "main")
     private Property<String> table;
 
     @Schema(
@@ -88,6 +95,7 @@ public class PGVector extends EmbeddingStoreProvider {
         description = "An IVFFlat index divides vectors into lists, and then searches a subset of those lists closest to the query vector. It has faster build times and uses less memory than HNSW but has lower query performance (in terms of speed-recall tradeoff)."
     )
     @Builder.Default
+    @PluginProperty(group = "advanced")
     private Property<Boolean> useIndex = Property.ofValue(false);
 
     @Override

--- a/src/main/java/io/kestra/plugin/ai/embeddings/Pinecone.java
+++ b/src/main/java/io/kestra/plugin/ai/embeddings/Pinecone.java
@@ -20,6 +20,7 @@ import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
+import io.kestra.core.models.annotations.PluginProperty;
 
 @Getter
 @SuperBuilder
@@ -62,21 +63,26 @@ public class Pinecone extends EmbeddingStoreProvider {
 
     @NotNull
     @Schema(title = "The API key")
+    @PluginProperty(group = "main")
     private Property<String> apiKey;
 
     @NotNull
     @Schema(title = "The cloud provider")
+    @PluginProperty(group = "main")
     private Property<String> cloud;
 
     @NotNull
     @Schema(title = "The cloud provider region")
+    @PluginProperty(group = "main")
     private Property<String> region;
 
     @NotNull
     @Schema(title = "The index")
+    @PluginProperty(group = "main")
     private Property<String> index;
 
     @Schema(title = "The namespace (default will be used if not provided)")
+    @PluginProperty(group = "connection")
     private Property<String> namespace;
 
     @Override

--- a/src/main/java/io/kestra/plugin/ai/embeddings/Qdrant.java
+++ b/src/main/java/io/kestra/plugin/ai/embeddings/Qdrant.java
@@ -19,6 +19,7 @@ import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
+import io.kestra.core.models.annotations.PluginProperty;
 
 @Getter
 @SuperBuilder
@@ -61,18 +62,22 @@ public class Qdrant extends EmbeddingStoreProvider {
 
     @NotNull
     @Schema(title = "The API key")
+    @PluginProperty(group = "main")
     private Property<String> apiKey;
 
     @NotNull
     @Schema(title = "The database server host")
+    @PluginProperty(group = "main")
     private Property<String> host;
 
     @NotNull
     @Schema(title = "The database server port")
+    @PluginProperty(group = "main")
     private Property<Integer> port;
 
     @NotNull
     @Schema(title = "The collection name")
+    @PluginProperty(group = "main")
     private Property<String> collectionName;
 
     @Override

--- a/src/main/java/io/kestra/plugin/ai/embeddings/Redis.java
+++ b/src/main/java/io/kestra/plugin/ai/embeddings/Redis.java
@@ -23,6 +23,7 @@ import lombok.experimental.SuperBuilder;
 import redis.clients.jedis.DefaultJedisClientConfig;
 import redis.clients.jedis.HostAndPort;
 import redis.clients.jedis.JedisPooled;
+import io.kestra.core.models.annotations.PluginProperty;
 
 @Getter
 @SuperBuilder
@@ -63,14 +64,17 @@ public class Redis extends EmbeddingStoreProvider {
 
     @NotNull
     @Schema(title = "The database server host")
+    @PluginProperty(group = "main")
     private Property<String> host;
 
     @NotNull
     @Schema(title = "The database server port")
+    @PluginProperty(group = "main")
     private Property<Integer> port;
 
     @Schema(title = "The index name")
     @Builder.Default
+    @PluginProperty(group = "advanced")
     private Property<String> indexName = Property.ofValue("embedding-index");
 
     @Override

--- a/src/main/java/io/kestra/plugin/ai/embeddings/Tablestore.java
+++ b/src/main/java/io/kestra/plugin/ai/embeddings/Tablestore.java
@@ -21,6 +21,7 @@ import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
+import io.kestra.core.models.annotations.PluginProperty;
 
 @Getter
 @SuperBuilder
@@ -62,21 +63,26 @@ public class Tablestore extends EmbeddingStoreProvider {
 
     @NotNull
     @Schema(title = "Endpoint URL", description = "The base URL for the Tablestore database endpoint.")
+    @PluginProperty(group = "main")
     private Property<String> endpoint;
 
     @NotNull
     @Schema(title = "Instance Name", description = "The name of the Tablestore database instance.")
+    @PluginProperty(group = "main")
     private Property<String> instanceName;
 
     @NotNull
     @Schema(title = "Access Key ID", description = "The access key ID used for authentication with the database.")
+    @PluginProperty(group = "main")
     private Property<String> accessKeyId;
 
     @NotNull
     @Schema(title = "Access Key Secret", description = "The access key secret used for authentication with the database.")
+    @PluginProperty(group = "main")
     private Property<String> accessKeySecret;
 
     @Schema(title = "Metadata Schema List", description = "Optional list of metadata field schemas for the collection.")
+    @PluginProperty(group = "advanced")
     private Property<List<FieldSchema>> metadataSchemaList;
 
     @Override

--- a/src/main/java/io/kestra/plugin/ai/embeddings/Weaviate.java
+++ b/src/main/java/io/kestra/plugin/ai/embeddings/Weaviate.java
@@ -20,6 +20,7 @@ import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
+import io.kestra.core.models.annotations.PluginProperty;
 
 @Getter
 @SuperBuilder
@@ -66,12 +67,14 @@ public class Weaviate extends EmbeddingStoreProvider {
         description = "Weaviate API key. Omit for local deployments without auth."
     )
     @NotNull
+    @PluginProperty(group = "main")
     private Property<String> apiKey;
 
     @Schema(
         title = "Scheme",
         description = "Cluster scheme: \"https\" (recommended) or \"http\"."
     )
+    @PluginProperty(group = "advanced")
     private Property<String> scheme;
 
     @Schema(
@@ -79,60 +82,70 @@ public class Weaviate extends EmbeddingStoreProvider {
         description = "Cluster host name without protocol, e.g., \"abc123.weaviate.network\"."
     )
     @NotNull
+    @PluginProperty(group = "main")
     private Property<String> host;
 
     @Schema(
         title = "Port",
         description = "Optional port (e.g., 443 for https, 80 for http). Leave unset to use provider defaults."
     )
+    @PluginProperty(group = "connection")
     private Property<Integer> port;
 
     @Schema(
         title = "Object class",
         description = "Weaviate class to store objects in (must start with an uppercase letter). Defaults to \"Default\" if not set."
     )
+    @PluginProperty(group = "advanced")
     private Property<String> objectClass;
 
     @Schema(
         title = "Consistency level",
         description = "Write consistency: ONE, QUORUM (default), or ALL."
     )
+    @PluginProperty(group = "advanced")
     private Property<ConsistencyLevel> consistencyLevel;
 
     @Schema(
         title = "Avoid duplicates",
         description = "If true (default), a hash-based ID is derived from each text segment to prevent duplicates. If false, a random ID is used."
     )
+    @PluginProperty(group = "advanced")
     private Property<Boolean> avoidDups;
 
     @Schema(
         title = "Metadata field name",
         description = "Field used to store metadata. Defaults to \"_metadata\" if not set."
     )
+    @PluginProperty(group = "advanced")
     private Property<String> metadataFieldName;
 
     @Schema(
         title = "Metadata keys",
         description = "The list of metadata keys to store - if not provided, it will default to an empty list."
     )
+    @PluginProperty(group = "advanced")
     private Property<List<String>> metadataKeys;
 
     @Schema(
         title = "Use gRPC for batch inserts",
         description = "If true, use gRPC for batch inserts. HTTP remains required for search operations."
     )
+    @PluginProperty(group = "advanced")
     private Property<Boolean> useGrpcForInserts;
 
     @Schema(
         title = "Secure gRPC",
         description = "Whether the gRPC connection is secured (TLS)."
     )
+    @PluginProperty(group = "advanced")
     private Property<Boolean> securedGrpc;
 
     @Schema(
         title = "gRPC port",
         description = "Port for gRPC if enabled (e.g., 50051)."
     )
+    @PluginProperty(group = "connection")
     private Property<Integer> grpcPort;
 
     @Override

--- a/src/main/java/io/kestra/plugin/ai/memory/PostgreSQL.java
+++ b/src/main/java/io/kestra/plugin/ai/memory/PostgreSQL.java
@@ -25,6 +25,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
+import io.kestra.core.models.annotations.PluginProperty;
 
 @Getter
 @SuperBuilder
@@ -72,22 +73,27 @@ public class PostgreSQL extends MemoryProvider {
 
     @NotNull
     @Schema(title = "PostgreSQL host", description = "The hostname of your PostgreSQL server")
+    @PluginProperty(group = "main")
     private Property<String> host;
 
     @Schema(title = "PostgreSQL port", description = "The port of your PostgreSQL server")
     @Builder.Default
+    @PluginProperty(group = "connection")
     private Property<Integer> port = Property.ofValue(5432);
 
     @NotNull
     @Schema(title = "Database name", description = "The name of the PostgreSQL database")
+    @PluginProperty(group = "main")
     private Property<String> database;
 
     @NotNull
     @Schema(title = "Database user", description = "The username to connect to PostgreSQL")
+    @PluginProperty(group = "main")
     private Property<String> user;
 
     @NotNull
     @Schema(title = "Database password", description = "The password to connect to PostgreSQL")
+    @PluginProperty(group = "main")
     private Property<String> password;
 
     @Schema(
@@ -95,6 +101,7 @@ public class PostgreSQL extends MemoryProvider {
         description = "The name of the table used to store chat memory. Defaults to 'chat_memory'."
     )
     @Builder.Default
+    @PluginProperty(group = "advanced")
     private Property<String> tableName = Property.ofValue("chat_memory");
 
     @Override

--- a/src/main/java/io/kestra/plugin/ai/memory/Redis.java
+++ b/src/main/java/io/kestra/plugin/ai/memory/Redis.java
@@ -24,6 +24,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
 import redis.clients.jedis.Jedis;
+import io.kestra.core.models.annotations.PluginProperty;
 
 @Getter
 @SuperBuilder
@@ -104,6 +105,7 @@ public class Redis extends MemoryProvider {
         title = "Redis host",
         description = "The hostname of your Redis server (e.g., localhost or redis-server)"
     )
+    @PluginProperty(group = "main")
     private Property<String> host;
 
     @Schema(
@@ -111,6 +113,7 @@ public class Redis extends MemoryProvider {
         description = "The port of your Redis server"
     )
     @Builder.Default
+    @PluginProperty(group = "connection")
     private Property<Integer> port = Property.ofValue(6379);
 
     @Override

--- a/src/main/java/io/kestra/plugin/ai/provider/AmazonBedrock.java
+++ b/src/main/java/io/kestra/plugin/ai/provider/AmazonBedrock.java
@@ -33,6 +33,7 @@ import lombok.experimental.SuperBuilder;
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.services.bedrockruntime.BedrockRuntimeClient;
+import io.kestra.core.models.annotations.PluginProperty;
 
 @Getter
 @SuperBuilder
@@ -81,15 +82,18 @@ public class AmazonBedrock extends ModelProvider {
 
     @Schema(title = "AWS Access Key ID")
     @NotNull
+    @PluginProperty(group = "main")
     private Property<String> accessKeyId;
 
     @Schema(title = "AWS Secret Access Key")
     @NotNull
+    @PluginProperty(group = "main")
     private Property<String> secretAccessKey;
 
     @Schema(title = "Amazon Bedrock Embedding Model Type")
     @NotNull
     @Builder.Default
+    @PluginProperty(group = "main")
     private Property<AmazonBedrockEmbeddingModelType> modelType = Property.ofValue(AmazonBedrockEmbeddingModelType.COHERE);
 
     @Override

--- a/src/main/java/io/kestra/plugin/ai/provider/Anthropic.java
+++ b/src/main/java/io/kestra/plugin/ai/provider/Anthropic.java
@@ -28,6 +28,7 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
+import io.kestra.core.models.annotations.PluginProperty;
 
 @Getter
 @SuperBuilder
@@ -77,12 +78,14 @@ public class Anthropic extends ModelProvider {
     private static final String ENABLED = "enabled";
     @Schema(title = "API Key")
     @NotNull
+    @PluginProperty(group = "main")
     private Property<String> apiKey;
     @Schema(
         title = "Maximum Tokens",
         description = """
             Specifies the maximum number of tokens that the model is allowed to generate in its response."""
     )
+    @PluginProperty(group = "execution")
     private Property<Integer> maxTokens;
 
     @Override

--- a/src/main/java/io/kestra/plugin/ai/provider/AzureOpenAI.java
+++ b/src/main/java/io/kestra/plugin/ai/provider/AzureOpenAI.java
@@ -33,6 +33,7 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
+import io.kestra.core.models.annotations.PluginProperty;
 
 @Getter
 @SuperBuilder
@@ -79,22 +80,28 @@ import lombok.experimental.SuperBuilder;
 public class AzureOpenAI extends ModelProvider {
 
     @Schema(title = "API Key")
+    @PluginProperty(group = "connection")
     private Property<String> apiKey;
 
     @Schema(title = "API endpoint", description = "The Azure OpenAI endpoint in the format: https://{resource}.openai.azure.com/")
     @NotNull
+    @PluginProperty(group = "main")
     private Property<String> endpoint;
 
     @Schema(title = "API version")
+    @PluginProperty(group = "advanced")
     private Property<String> serviceVersion;
 
     @Schema(title = "Tenant ID")
+    @PluginProperty(group = "connection")
     private Property<String> tenantId;
 
     @Schema(title = "Client ID")
+    @PluginProperty(group = "connection")
     private Property<String> clientId;
 
     @Schema(title = "Client secret")
+    @PluginProperty(group = "connection")
     private Property<String> clientSecret;
 
     @Override

--- a/src/main/java/io/kestra/plugin/ai/provider/DashScope.java
+++ b/src/main/java/io/kestra/plugin/ai/provider/DashScope.java
@@ -28,6 +28,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
+import io.kestra.core.models.annotations.PluginProperty;
 
 @Getter
 @SuperBuilder
@@ -77,6 +78,7 @@ public class DashScope extends ModelProvider {
         : DASHSCOPE_INTL_URL;
     @Schema(title = "API Key")
     @NotNull
+    @PluginProperty(group = "main")
     private Property<String> apiKey;
 
     @Schema(
@@ -89,6 +91,7 @@ public class DashScope extends ModelProvider {
     )
     @NotNull
     @Builder.Default
+    @PluginProperty(group = "main")
     private Property<String> baseUrl = Property.ofValue(DASHSCOPE_BASE_URL);
 
     @Schema(
@@ -98,14 +101,17 @@ public class DashScope extends ModelProvider {
                 1.0 means no penalty. Value range: (0, +inf)
             """
     )
+    @PluginProperty(group = "advanced")
     private Property<Float> repetitionPenalty;
 
     @Schema(
         title = "Whether the model uses Internet search results for reference when generating text or not"
     )
+    @PluginProperty(group = "advanced")
     private Property<Boolean> enableSearch;
 
     @Schema(title = "The maximum number of tokens returned by this request")
+    @PluginProperty(group = "execution")
     private Property<Integer> maxTokens;
 
     @Override

--- a/src/main/java/io/kestra/plugin/ai/provider/DeepSeek.java
+++ b/src/main/java/io/kestra/plugin/ai/provider/DeepSeek.java
@@ -11,6 +11,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
+import io.kestra.core.models.annotations.PluginProperty;
 
 @Getter
 @SuperBuilder
@@ -57,5 +58,6 @@ public class DeepSeek extends OpenAICompliantProvider {
 
     @Schema(title = "API base URL")
     @Builder.Default
+    @PluginProperty(group = "connection")
     private Property<String> baseUrl = Property.ofValue(BASE_URL);
 }

--- a/src/main/java/io/kestra/plugin/ai/provider/GitHubModels.java
+++ b/src/main/java/io/kestra/plugin/ai/provider/GitHubModels.java
@@ -29,6 +29,7 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
+import io.kestra.core.models.annotations.PluginProperty;
 
 @Getter
 @SuperBuilder
@@ -77,6 +78,7 @@ public class GitHubModels extends ModelProvider {
         description = "Personal Access Token (PAT) used to access GitHub Models."
     )
     @NotNull
+    @PluginProperty(group = "main")
     private Property<String> gitHubToken;
 
     @Override

--- a/src/main/java/io/kestra/plugin/ai/provider/GoogleGemini.java
+++ b/src/main/java/io/kestra/plugin/ai/provider/GoogleGemini.java
@@ -29,6 +29,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
+import io.kestra.core.models.annotations.PluginProperty;
 
 @Getter
 @SuperBuilder
@@ -113,9 +114,11 @@ public class GoogleGemini extends ModelProvider {
         title = "API Key",
         description = "Required unless certificate-based authentication is configured with `clientPem` (optionally with `caPem`)."
     )
+    @PluginProperty(group = "connection")
     private Property<String> apiKey;
 
     @Schema(title = "The configuration for embeddingModel")
+    @PluginProperty(group = "advanced")
     private EmbeddingModelConfiguration embeddingModelConfiguration;
 
     @Override
@@ -219,18 +222,22 @@ public class GoogleGemini extends ModelProvider {
             title = "The headline or name of the document (passed to the model as metadata).",
             description = "If set, this help improving retrieval quality by providing context for a document."
         )
+        @PluginProperty(group = "connection")
         private Property<String> titleMetadataKey;
 
         @Schema(title = "Used to convey intended downstream application to help the model produce better embeddings.")
         private Property<GoogleAiEmbeddingModel.TaskType> taskType;
 
         @Schema(title = "Maximum number of retries for failed requests")
+        @PluginProperty(group = "execution")
         private Property<Integer> maxRetries;
 
         @Schema(title = "Timeout in seconds for each request")
+        @PluginProperty(group = "execution")
         private Property<Duration> timeout;
 
         @Schema(title = "Used to specify output embedding size", description = "If set, output embeddings will be truncated to the size specified.")
+        @PluginProperty(group = "advanced")
         private Property<Integer> outputDimensionality;
     }
 }

--- a/src/main/java/io/kestra/plugin/ai/provider/GoogleVertexAI.java
+++ b/src/main/java/io/kestra/plugin/ai/provider/GoogleVertexAI.java
@@ -30,6 +30,7 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
+import io.kestra.core.models.annotations.PluginProperty;
 
 @Getter
 @SuperBuilder
@@ -76,14 +77,17 @@ import lombok.experimental.SuperBuilder;
 public class GoogleVertexAI extends ModelProvider {
     @Schema(title = "Endpoint URL")
     @NotNull
+    @PluginProperty(group = "main")
     private Property<String> endpoint;
 
     @Schema(title = "Project location")
     @NotNull
+    @PluginProperty(group = "main")
     private Property<String> location;
 
     @Schema(title = "Project ID")
     @NotNull
+    @PluginProperty(group = "main")
     private Property<String> project;
 
     @Override

--- a/src/main/java/io/kestra/plugin/ai/provider/HuggingFace.java
+++ b/src/main/java/io/kestra/plugin/ai/provider/HuggingFace.java
@@ -11,6 +11,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
+import io.kestra.core.models.annotations.PluginProperty;
 
 @Getter
 @SuperBuilder
@@ -56,5 +57,6 @@ public class HuggingFace extends OpenAICompliantProvider {
 
     @Schema(title = "API base URL")
     @Builder.Default
+    @PluginProperty(group = "connection")
     private Property<String> baseUrl = Property.ofValue(BASE_URL);
 }

--- a/src/main/java/io/kestra/plugin/ai/provider/LocalAI.java
+++ b/src/main/java/io/kestra/plugin/ai/provider/LocalAI.java
@@ -21,6 +21,7 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
+import io.kestra.core.models.annotations.PluginProperty;
 
 @Getter
 @SuperBuilder
@@ -67,6 +68,7 @@ public class LocalAI extends ModelProvider {
 
     @Schema(title = "API base URL")
     @NotNull
+    @PluginProperty(group = "main")
     private Property<String> baseUrl;
 
     @Override

--- a/src/main/java/io/kestra/plugin/ai/provider/MistralAI.java
+++ b/src/main/java/io/kestra/plugin/ai/provider/MistralAI.java
@@ -32,6 +32,7 @@ import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
 
 import static dev.langchain4j.model.chat.Capability.RESPONSE_FORMAT_JSON_SCHEMA;
+import io.kestra.core.models.annotations.PluginProperty;
 
 @Getter
 @SuperBuilder
@@ -78,6 +79,7 @@ public class MistralAI extends ModelProvider {
 
     @Schema(title = "API Key")
     @NotNull
+    @PluginProperty(group = "main")
     private Property<String> apiKey;
 
     @Override

--- a/src/main/java/io/kestra/plugin/ai/provider/OciGenAI.java
+++ b/src/main/java/io/kestra/plugin/ai/provider/OciGenAI.java
@@ -28,6 +28,7 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
+import io.kestra.core.models.annotations.PluginProperty;
 
 @Getter
 @SuperBuilder
@@ -76,13 +77,16 @@ public class OciGenAI extends ModelProvider {
     private static final String DEFAULT = "DEFAULT";
     @Schema(title = "OCID of OCI Compartment with the model")
     @NotNull
+    @PluginProperty(group = "main")
     private Property<String> compartmentId;
 
     @Schema(title = "OCI Region to connect the client to")
     @NotNull
+    @PluginProperty(group = "main")
     private Property<String> region;
 
     @Schema(title = "OCI SDK Authentication provider")
+    @PluginProperty(group = "connection")
     private Property<String> authProvider;
 
     @Override

--- a/src/main/java/io/kestra/plugin/ai/provider/Ollama.java
+++ b/src/main/java/io/kestra/plugin/ai/provider/Ollama.java
@@ -28,6 +28,7 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
+import io.kestra.core.models.annotations.PluginProperty;
 
 @Getter
 @SuperBuilder
@@ -75,6 +76,7 @@ import lombok.experimental.SuperBuilder;
 public class Ollama extends ModelProvider {
     @Schema(title = "Model endpoint")
     @NotNull
+    @PluginProperty(group = "main")
     private Property<String> endpoint;
 
     @Override

--- a/src/main/java/io/kestra/plugin/ai/provider/OpenAI.java
+++ b/src/main/java/io/kestra/plugin/ai/provider/OpenAI.java
@@ -12,6 +12,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
+import io.kestra.core.models.annotations.PluginProperty;
 
 @Getter
 @SuperBuilder
@@ -56,5 +57,6 @@ import lombok.experimental.SuperBuilder;
 public class OpenAI extends OpenAICompliantProvider {
     @Schema(title = "API base URL")
     @Builder.Default
+    @PluginProperty(group = "connection")
     private Property<String> baseUrl = Property.ofValue(OpenAiUtils.DEFAULT_OPENAI_URL);
 }

--- a/src/main/java/io/kestra/plugin/ai/provider/OpenAICompliantProvider.java
+++ b/src/main/java/io/kestra/plugin/ai/provider/OpenAICompliantProvider.java
@@ -31,6 +31,7 @@ import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
 
 import static dev.langchain4j.model.chat.Capability.RESPONSE_FORMAT_JSON_SCHEMA;
+import io.kestra.core.models.annotations.PluginProperty;
 
 @Getter
 @SuperBuilder
@@ -40,6 +41,7 @@ import static dev.langchain4j.model.chat.Capability.RESPONSE_FORMAT_JSON_SCHEMA;
 public abstract class OpenAICompliantProvider extends ModelProvider {
     @Schema(title = "API Key")
     @NotNull
+    @PluginProperty(group = "main")
     private Property<String> apiKey;
 
     @Override

--- a/src/main/java/io/kestra/plugin/ai/provider/OpenRouter.java
+++ b/src/main/java/io/kestra/plugin/ai/provider/OpenRouter.java
@@ -29,6 +29,7 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
+import io.kestra.core.models.annotations.PluginProperty;
 
 @Getter
 @SuperBuilder
@@ -78,6 +79,7 @@ public class OpenRouter extends ModelProvider {
 
     @Schema(title = "API Key")
     @NotNull
+    @PluginProperty(group = "main")
     private Property<String> apiKey;
 
     @Override

--- a/src/main/java/io/kestra/plugin/ai/provider/WatsonxAI.java
+++ b/src/main/java/io/kestra/plugin/ai/provider/WatsonxAI.java
@@ -21,6 +21,7 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
+import io.kestra.core.models.annotations.PluginProperty;
 
 @Getter
 @SuperBuilder
@@ -65,10 +66,12 @@ import lombok.experimental.SuperBuilder;
 public class WatsonxAI extends ModelProvider {
     @Schema(title = "API Key")
     @NotNull
+    @PluginProperty(group = "main")
     private Property<String> apiKey;
 
     @Schema(title = "Project Id")
     @NotNull
+    @PluginProperty(group = "main")
     private Property<String> projectId;
 
     @Override

--- a/src/main/java/io/kestra/plugin/ai/provider/WorkersAI.java
+++ b/src/main/java/io/kestra/plugin/ai/provider/WorkersAI.java
@@ -22,6 +22,7 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
+import io.kestra.core.models.annotations.PluginProperty;
 
 @Getter
 @SuperBuilder
@@ -68,6 +69,7 @@ import lombok.experimental.SuperBuilder;
 public class WorkersAI extends ModelProvider {
     @Schema(title = "API Key")
     @NotNull
+    @PluginProperty(group = "main")
     private Property<String> apiKey;
 
     @Schema(
@@ -75,6 +77,7 @@ public class WorkersAI extends ModelProvider {
         description = "Unique identifier assigned to an account"
     )
     @NotNull
+    @PluginProperty(group = "main")
     private Property<String> accountId;
 
     @Override

--- a/src/main/java/io/kestra/plugin/ai/provider/ZhiPuAI.java
+++ b/src/main/java/io/kestra/plugin/ai/provider/ZhiPuAI.java
@@ -29,6 +29,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
+import io.kestra.core.models.annotations.PluginProperty;
 
 @Getter
 @SuperBuilder
@@ -73,6 +74,7 @@ public class ZhiPuAI extends ModelProvider {
 
     @Schema(title = "API Key")
     @NotNull
+    @PluginProperty(group = "main")
     private Property<String> apiKey;
 
     @Schema(
@@ -80,15 +82,19 @@ public class ZhiPuAI extends ModelProvider {
     )
     @NotNull
     @Builder.Default
+    @PluginProperty(group = "main")
     private Property<String> baseUrl = Property.ofValue(BASE_URL);
 
     @Schema(title = "With the stop parameter, the model will automatically stop generating text when it is about to contain the specified string or token_id")
+    @PluginProperty(group = "advanced")
     private Property<List<String>> stops;
 
     @Schema(title = "The maximum retry times to request")
+    @PluginProperty(group = "execution")
     private Property<Integer> maxRetries;
 
     @Schema(title = "The maximum number of tokens returned by this request")
+    @PluginProperty(group = "connection")
     private Property<Integer> maxToken;
 
     @Override

--- a/src/main/java/io/kestra/plugin/ai/rag/ChatCompletion.java
+++ b/src/main/java/io/kestra/plugin/ai/rag/ChatCompletion.java
@@ -267,40 +267,42 @@ import static io.kestra.core.utils.Rethrow.throwFunction;
 public class ChatCompletion extends Task implements RunnableTask<ChatCompletion.Output> {
 
     @Schema(title = "System message", description = "Instruction that sets the assistant's role, tone, and constraints for this task.")
+    @PluginProperty(group = "advanced")
     protected Property<String> systemMessage;
 
     @Schema(title = "User prompt", description = "The user input for this run. May be templated from flow inputs.")
     @NotNull
+    @PluginProperty(group = "main")
     protected Property<String> prompt;
 
     @Schema(
         title = "Embedding store",
         description = "Optional when at least one entry is provided in `contentRetrievers`."
     )
-    @PluginProperty
+    @PluginProperty(group = "advanced")
     private EmbeddingStoreProvider embeddings;
 
     @Schema(
         title = "Embedding model provider",
         description = "Optional. If not set, the embedding model is created from `chatProvider`. Ensure the chosen chat provider supports embeddings."
     )
-    @PluginProperty
+    @PluginProperty(group = "advanced")
     private ModelProvider embeddingProvider;
 
     @Schema(title = "Chat model provider")
     @NotNull
-    @PluginProperty
+    @PluginProperty(group = "main")
     private ModelProvider chatProvider;
 
     @Schema(title = "Chat configuration")
     @NotNull
-    @PluginProperty
+    @PluginProperty(group = "advanced")
     @Builder.Default
     private ChatConfiguration chatConfiguration = ChatConfiguration.empty();
 
     @Schema(title = "Content retriever configuration")
     @NotNull
-    @PluginProperty
+    @PluginProperty(group = "advanced")
     @Builder.Default
     private ContentRetrieverConfiguration contentRetrieverConfiguration = ContentRetrieverConfiguration.builder().build();
 
@@ -308,15 +310,18 @@ public class ChatCompletion extends Task implements RunnableTask<ChatCompletion.
         title = "Additional content retrievers",
         description = "Some content retrievers like WebSearch can also be used as tools, but using them as content retrievers will ensure that they are always called whereas tools are only used when the LLM decides to."
     )
+    @PluginProperty(group = "advanced")
     private Property<List<ContentRetrieverProvider>> contentRetrievers;
 
     @Schema(title = "Optional tools the LLM may call to augment its response")
+    @PluginProperty(group = "destination")
     private List<ToolProvider> tools;
 
     @Schema(
         title = "Chat memory",
         description = "Stores conversation history and injects it into context on subsequent runs."
     )
+    @PluginProperty(group = "execution")
     private MemoryProvider memory;
 
     @Schema(

--- a/src/main/java/io/kestra/plugin/ai/rag/IngestDocument.java
+++ b/src/main/java/io/kestra/plugin/ai/rag/IngestDocument.java
@@ -105,40 +105,44 @@ public class IngestDocument extends Task implements RunnableTask<IngestDocument.
         description = "Must be configured with an embedding model."
     )
     @NotNull
-    @PluginProperty
+    @PluginProperty(group = "main")
     private ModelProvider provider;
 
     @Schema(title = "Embedding store provider")
     @NotNull
-    @PluginProperty
+    @PluginProperty(group = "main")
     private EmbeddingStoreProvider embeddings;
 
     @Schema(
         title = "Path in the task working directory containing documents to ingest",
         description = "Each document in the directory will be ingested into the embedding store. Ingestion is recursive and protected against path traversal (CWE-22)."
     )
+    @PluginProperty(group = "source")
     private Property<String> fromPath;
 
     @Schema(title = "List of internal storage URIs for documents")
-    @PluginProperty(internalStorageURI = true)
+    @PluginProperty(internalStorageURI = true, group = "connection")
     private Property<List<String>> fromInternalURIs;
 
     @Schema(title = "List of document URLs from external sources")
+    @PluginProperty(group = "connection")
     private Property<List<String>> fromExternalURLs;
 
     @Schema(title = "List of inline documents")
-    @PluginProperty
+    @PluginProperty(group = "source")
     private List<InlineDocument> fromDocuments;
 
     @Schema(title = "Additional metadata to add to all ingested documents")
+    @PluginProperty(group = "advanced")
     private Property<Map<String, String>> metadata;
 
     @Schema(title = "Document splitter")
-    @PluginProperty
+    @PluginProperty(group = "advanced")
     private DocumentSplitter documentSplitter;
 
     @Schema(title = "Drop the store before ingestion (useful for testing)")
     @Builder.Default
+    @PluginProperty(group = "advanced")
     private Property<Boolean> drop = Property.ofValue(Boolean.FALSE);
 
     @Schema(
@@ -296,6 +300,7 @@ public class IngestDocument extends Task implements RunnableTask<IngestDocument.
         private Property<String> content;
 
         @Schema(title = "Document metadata")
+        @PluginProperty(group = "advanced")
         private Property<Map<String, Object>> metadata;
     }
 

--- a/src/main/java/io/kestra/plugin/ai/rag/Search.java
+++ b/src/main/java/io/kestra/plugin/ai/rag/Search.java
@@ -95,28 +95,32 @@ public class Search extends Task implements RunnableTask<Search.Output> {
 
     @Schema(title = "Query string")
     @NotNull
+    @PluginProperty(group = "main")
     private Property<String> query;
 
     @Schema(title = "Maximum number of results")
     @NotNull
+    @PluginProperty(group = "main")
     private Property<Integer> maxResults;
 
     @Schema(title = "Minimum similarity score")
     @NotNull
+    @PluginProperty(group = "main")
     private Property<Double> minScore;
 
     @Schema(title = "Embedding model provider")
     @NotNull
-    @PluginProperty
+    @PluginProperty(group = "main")
     private ModelProvider provider;
 
     @Schema(title = "Embedding store provider")
     @NotNull
-    @PluginProperty
+    @PluginProperty(group = "main")
     private EmbeddingStoreProvider embeddings;
 
     @NotNull
     @Builder.Default
+    @PluginProperty(group = "processing")
     protected Property<FetchType> fetchType = Property.ofValue(NONE);
 
     @Override

--- a/src/main/java/io/kestra/plugin/ai/retriever/EmbeddingStoreRetriever.java
+++ b/src/main/java/io/kestra/plugin/ai/retriever/EmbeddingStoreRetriever.java
@@ -122,7 +122,7 @@ public class EmbeddingStoreRetriever extends ContentRetrieverProvider {
         description = "The embedding store to retrieve relevant content from"
     )
     @NotNull
-    @PluginProperty
+    @PluginProperty(group = "main")
     private EmbeddingStoreProvider embeddings;
 
     @Schema(
@@ -130,12 +130,13 @@ public class EmbeddingStoreRetriever extends ContentRetrieverProvider {
         description = "Provider used to generate embeddings for the query. Must support embedding generation."
     )
     @NotNull
-    @PluginProperty
+    @PluginProperty(group = "main")
     private ModelProvider embeddingProvider;
 
     @Schema(title = "Maximum number of results to return from the embedding store")
     @NotNull
     @Builder.Default
+    @PluginProperty(group = "main")
     private Property<Integer> maxResults = Property.ofValue(3);
 
     @Schema(
@@ -144,6 +145,7 @@ public class EmbeddingStoreRetriever extends ContentRetrieverProvider {
     )
     @NotNull
     @Builder.Default
+    @PluginProperty(group = "main")
     private Property<Double> minScore = Property.ofValue(0.0);
 
     @Override

--- a/src/main/java/io/kestra/plugin/ai/retriever/GoogleCustomWebSearch.java
+++ b/src/main/java/io/kestra/plugin/ai/retriever/GoogleCustomWebSearch.java
@@ -20,6 +20,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
+import io.kestra.core.models.annotations.PluginProperty;
 
 @Getter
 @SuperBuilder
@@ -59,15 +60,18 @@ import lombok.experimental.SuperBuilder;
 public class GoogleCustomWebSearch extends ContentRetrieverProvider {
     @Schema(title = "Custom search engine ID (cx)")
     @NotNull
+    @PluginProperty(group = "main")
     private Property<String> csi;
 
     @Schema(title = "API key")
     @NotNull
+    @PluginProperty(group = "main")
     private Property<String> apiKey;
 
     @Schema(title = "Maximum number of results")
     @NotNull
     @Builder.Default
+    @PluginProperty(group = "main")
     private Property<Integer> maxResults = Property.ofValue(3);
 
     @Override

--- a/src/main/java/io/kestra/plugin/ai/retriever/SqlDatabaseRetriever.java
+++ b/src/main/java/io/kestra/plugin/ai/retriever/SqlDatabaseRetriever.java
@@ -78,34 +78,40 @@ public class SqlDatabaseRetriever extends ContentRetrieverProvider {
 
     @Schema(title = "Type of database to connect to (PostgreSQL, MySQL, or H2)")
     @NotNull
+    @PluginProperty(group = "main")
     private Property<DatabaseType> databaseType;
 
     @Schema(title = "JDBC connection URL to the target database")
+    @PluginProperty(group = "connection")
     private Property<String> jdbcUrl;
 
     @Schema(title = "Database username")
     @NotNull
+    @PluginProperty(group = "main")
     private Property<String> username;
 
     @Schema(title = "Database password")
     @NotNull
+    @PluginProperty(group = "main")
     private Property<String> password;
 
     @Schema(title = "Optional JDBC driver class name – automatically resolved if not provided.")
+    @PluginProperty(group = "advanced")
     private Property<String> driver;
 
     @Schema(title = "Maximum number of database connections in the pool")
     @Builder.Default
+    @PluginProperty(group = "execution")
     private Property<Integer> maxPoolSize = Property.ofValue(2);
 
     @Schema(title = "Language model provider")
     @NotNull
-    @PluginProperty
+    @PluginProperty(group = "main")
     private ModelProvider provider;
 
     @Schema(title = "Language model configuration")
     @NotNull
-    @PluginProperty
+    @PluginProperty(group = "main")
     @Builder.Default
     private ChatConfiguration configuration = ChatConfiguration.empty();
 

--- a/src/main/java/io/kestra/plugin/ai/retriever/TavilyWebSearch.java
+++ b/src/main/java/io/kestra/plugin/ai/retriever/TavilyWebSearch.java
@@ -20,6 +20,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
+import io.kestra.core.models.annotations.PluginProperty;
 
 @Getter
 @SuperBuilder
@@ -58,11 +59,13 @@ import lombok.experimental.SuperBuilder;
 public class TavilyWebSearch extends ContentRetrieverProvider {
     @Schema(title = "API Key")
     @NotNull
+    @PluginProperty(group = "main")
     private Property<String> apiKey;
 
     @Schema(title = "Maximum number of results to return")
     @NotNull
     @Builder.Default
+    @PluginProperty(group = "main")
     private Property<Integer> maxResults = Property.ofValue(3);
 
     @Override

--- a/src/main/java/io/kestra/plugin/ai/tool/A2AClient.java
+++ b/src/main/java/io/kestra/plugin/ai/tool/A2AClient.java
@@ -24,6 +24,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
+import io.kestra.core.models.annotations.PluginProperty;
 
 @Getter
 @SuperBuilder
@@ -76,6 +77,7 @@ public class A2AClient extends ToolProvider {
     )
     @NotNull
     @Builder.Default
+    @PluginProperty(group = "main")
     protected Property<String> name = Property.ofValue("tool");
 
     @Schema(
@@ -83,10 +85,12 @@ public class A2AClient extends ToolProvider {
         description = "The description will be used to instruct the LLM what the tool is doing."
     )
     @NotNull
+    @PluginProperty(group = "main")
     protected Property<String> description;
 
     @Schema(title = "Server URL", description = "The URL of the remote agent A2A server")
     @NotNull
+    @PluginProperty(group = "main")
     protected Property<String> serverUrl;
 
     @Override

--- a/src/main/java/io/kestra/plugin/ai/tool/AIAgent.java
+++ b/src/main/java/io/kestra/plugin/ai/tool/AIAgent.java
@@ -92,6 +92,7 @@ public class AIAgent extends ToolProvider {
     )
     @NotNull
     @Builder.Default
+    @PluginProperty(group = "main")
     protected Property<String> name = Property.ofValue("tool");
 
     @Schema(
@@ -99,32 +100,37 @@ public class AIAgent extends ToolProvider {
         description = "The description will be used to instruct the LLM what the tool is doing."
     )
     @NotNull
+    @PluginProperty(group = "main")
     protected Property<String> description;
 
     @Schema(title = "System message", description = "The system message for the language model")
+    @PluginProperty(group = "advanced")
     protected Property<String> systemMessage;
 
     @Schema(title = "Language model provider")
     @NotNull
-    @PluginProperty
+    @PluginProperty(group = "main")
     private ModelProvider provider;
 
     @Schema(title = "Language model configuration")
     @NotNull
-    @PluginProperty
+    @PluginProperty(group = "main")
     @Builder.Default
     private ChatConfiguration configuration = ChatConfiguration.empty();
 
     @Schema(title = "Tools that the LLM may use to augment its response")
+    @PluginProperty(group = "advanced")
     private List<ToolProvider> tools;
 
     @Schema(title = "Maximum sequential tools invocations")
+    @PluginProperty(group = "execution")
     private Property<Integer> maxSequentialToolsInvocations;
 
     @Schema(
         title = "Content retrievers",
         description = "Some content retrievers, like WebSearch, can also be used as tools. However, when configured as content retrievers, they will always be used, whereas tools are only invoked when the LLM decides to use them."
     )
+    @PluginProperty(group = "advanced")
     private Property<List<ContentRetrieverProvider>> contentRetrievers;
 
     @Getter(AccessLevel.NONE)

--- a/src/main/java/io/kestra/plugin/ai/tool/CodeExecution.java
+++ b/src/main/java/io/kestra/plugin/ai/tool/CodeExecution.java
@@ -20,6 +20,7 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
+import io.kestra.core.models.annotations.PluginProperty;
 
 @Getter
 @SuperBuilder
@@ -62,6 +63,7 @@ public class CodeExecution extends ToolProvider {
         description = "You can obtain it from the [RapidAPI website](https://rapidapi.com/judge0-official/api/judge0-ce/pricing)."
     )
     @NotNull
+    @PluginProperty(group = "main")
     private Property<String> apiKey;
 
     @Override

--- a/src/main/java/io/kestra/plugin/ai/tool/DockerMcpClient.java
+++ b/src/main/java/io/kestra/plugin/ai/tool/DockerMcpClient.java
@@ -23,6 +23,7 @@ import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
 
 import static io.kestra.core.utils.Rethrow.throwSupplier;
+import io.kestra.core.models.annotations.PluginProperty;
 
 @Getter
 @SuperBuilder
@@ -97,51 +98,66 @@ import static io.kestra.core.utils.Rethrow.throwSupplier;
 )
 public class DockerMcpClient extends AbstractMcpClient {
     @Schema(title = "MCP client command, as a list of command parts")
+    @PluginProperty(group = "advanced")
     private Property<List<String>> command;
 
     @Schema(title = "Environment variables")
+    @PluginProperty(group = "execution")
     private Property<Map<String, String>> env;
 
     @Schema(title = "Container image")
     @NotNull
+    @PluginProperty(group = "main")
     private Property<String> image;
 
     @Schema(title = "Whether to log events")
     @NotNull
     @Builder.Default
+    @PluginProperty(group = "main")
     private Property<Boolean> logEvents = Property.ofValue(false);
 
     @Schema(title = "Docker host")
+    @PluginProperty(group = "connection")
     private Property<String> dockerHost;
 
     @Schema(title = "Docker configuration")
+    @PluginProperty(group = "advanced")
     private Property<String> dockerConfig;
 
     @Schema(title = "Docker context")
+    @PluginProperty(group = "advanced")
     private Property<String> dockerContext;
 
     @Schema(title = "Docker certificate path")
+    @PluginProperty(group = "advanced")
     private Property<String> dockerCertPath;
 
     @Schema(title = "Whether Docker should verify TLS certificates")
+    @PluginProperty(group = "advanced")
     private Property<Boolean> dockerTlsVerify;
 
     @Schema(title = "Container registry email")
+    @PluginProperty(group = "advanced")
     private Property<String> registryEmail;
 
     @Schema(title = "Container registry password")
+    @PluginProperty(group = "connection")
     private Property<String> registryPassword;
 
     @Schema(title = "Container registry username")
+    @PluginProperty(group = "connection")
     private Property<String> registryUsername;
 
     @Schema(title = "Container registry URL")
+    @PluginProperty(group = "connection")
     private Property<String> registryUrl;
 
     @Schema(title = "API version")
+    @PluginProperty(group = "advanced")
     private Property<String> apiVersion;
 
     @Schema(title = "Volume binds")
+    @PluginProperty(group = "advanced")
     private Property<List<String>> binds;
 
     @Override

--- a/src/main/java/io/kestra/plugin/ai/tool/GoogleCustomWebSearch.java
+++ b/src/main/java/io/kestra/plugin/ai/tool/GoogleCustomWebSearch.java
@@ -22,6 +22,7 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
+import io.kestra.core.models.annotations.PluginProperty;
 
 @Getter
 @SuperBuilder
@@ -69,10 +70,12 @@ import lombok.experimental.SuperBuilder;
 public class GoogleCustomWebSearch extends ToolProvider {
     @Schema(title = "Custom search engine ID (cx)")
     @NotNull
+    @PluginProperty(group = "main")
     private Property<String> csi;
 
     @Schema(title = "API key")
     @NotNull
+    @PluginProperty(group = "main")
     private Property<String> apiKey;
 
     @Override

--- a/src/main/java/io/kestra/plugin/ai/tool/KestraFlow.java
+++ b/src/main/java/io/kestra/plugin/ai/tool/KestraFlow.java
@@ -189,22 +189,26 @@ public class KestraFlow extends ToolProvider {
             The LLM needs a tool description to identify whether to call it.
             If the flow has a description, the tool will use it. Otherwise, the description property must be explicitly defined."""
     )
+    @PluginProperty(group = "advanced")
     private Property<String> description;
 
     @Schema(title = "Namespace of the flow that should be called")
+    @PluginProperty(group = "connection")
     private Property<String> namespace;
 
     @Schema(title = "Flow ID of the flow that should be called")
+    @PluginProperty(group = "advanced")
     private Property<String> flowId;
 
     @Schema(title = "Revision of the flow that should be called")
+    @PluginProperty(group = "advanced")
     private Property<Integer> revision;
 
     @Schema(
         title = "Input values that should be passed to flow's execution",
         description = "Any inputs passed by the LLM will override those defined here."
     )
-    @PluginProperty(dynamic = true)
+    @PluginProperty(dynamic = true, group = "advanced")
     private Map<String, Object> inputs;
 
     @Schema(
@@ -224,12 +228,14 @@ public class KestraFlow extends ToolProvider {
             By default, labels are not inherited. If you set this option to `true`, the flow execution will inherit all labels from the agent's execution.
             Any labels passed by the LLM will override those defined here."""
     )
+    @PluginProperty(group = "advanced")
     private final Property<Boolean> inheritLabels = Property.ofValue(false);
 
     @Schema(
         title = "Schedule the flow execution at a later date",
         description = "If the LLM sets a scheduleDate, it will override the one defined here."
     )
+    @PluginProperty(group = "advanced")
     private Property<ZonedDateTime> scheduleDate;
 
     @Override

--- a/src/main/java/io/kestra/plugin/ai/tool/KestraTask.java
+++ b/src/main/java/io/kestra/plugin/ai/tool/KestraTask.java
@@ -33,6 +33,7 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
+import io.kestra.core.models.annotations.PluginProperty;
 
 @Getter
 @SuperBuilder
@@ -82,6 +83,7 @@ public class KestraTask extends ToolProvider {
 
     @Schema(title = "List of Kestra runnable tasks")
     @NotNull
+    @PluginProperty(group = "main")
     private List<Task> tasks;
 
     @Override

--- a/src/main/java/io/kestra/plugin/ai/tool/Skill.java
+++ b/src/main/java/io/kestra/plugin/ai/tool/Skill.java
@@ -121,7 +121,7 @@ public class Skill extends ToolProvider {
             pointing to Kestra internal storage."""
     )
     @NotNull
-    @PluginProperty
+    @PluginProperty(group = "main")
     private List<SkillDefinition> skills;
 
     @Override
@@ -213,30 +213,33 @@ public class Skill extends ToolProvider {
     public static class SkillDefinition {
         @Schema(title = "Name of the skill")
         @NotNull
+        @PluginProperty(group = "main")
         private Property<String> name;
 
         @Schema(title = "Description of the skill used by the LLM to decide when to activate it")
         @NotNull
+        @PluginProperty(group = "main")
         private Property<String> description;
 
         @Schema(
             title = "Inline content of the skill",
             description = "Mutually exclusive with 'contentUri'. At least one of 'content' or 'contentUri' must be set."
         )
+        @PluginProperty(group = "advanced")
         private Property<String> content;
 
         @Schema(
             title = "URI to the skill content in Kestra internal storage",
             description = "Mutually exclusive with 'content'. At least one of 'content' or 'contentUri' must be set."
         )
-        @PluginProperty(internalStorageURI = true)
+        @PluginProperty(internalStorageURI = true, group = "advanced")
         private Property<String> contentUri;
 
         @Schema(
             title = "Additional resources attached to this skill",
             description = "Resources the agent can read separately using the 'read_skill_resource' tool."
         )
-        @PluginProperty
+        @PluginProperty(group = "advanced")
         private List<ResourceDefinition> resources;
     }
 
@@ -246,10 +249,12 @@ public class Skill extends ToolProvider {
     public static class ResourceDefinition {
         @Schema(title = "Relative path of the resource within the skill")
         @NotNull
+        @PluginProperty(group = "main")
         private Property<String> relativePath;
 
         @Schema(title = "Content of the resource")
         @NotNull
+        @PluginProperty(group = "main")
         private Property<String> content;
     }
 }

--- a/src/main/java/io/kestra/plugin/ai/tool/SseMcpClient.java
+++ b/src/main/java/io/kestra/plugin/ai/tool/SseMcpClient.java
@@ -20,6 +20,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
+import io.kestra.core.models.annotations.PluginProperty;
 
 @Getter
 @SuperBuilder
@@ -68,25 +69,30 @@ import lombok.experimental.SuperBuilder;
 public class SseMcpClient extends AbstractMcpClient {
     @Schema(title = "SSE URL of the MCP server")
     @NotNull
+    @PluginProperty(group = "main")
     private Property<String> sseUrl;
 
     @Schema(title = "Connection timeout duration")
+    @PluginProperty(group = "execution")
     private Property<Duration> timeout;
 
     @Schema(
         title = "Custom headers",
         description = "Could be useful, for example, to add authentication tokens via the `Authorization` header."
     )
+    @PluginProperty(group = "advanced")
     private Property<Map<String, String>> headers;
 
     @Schema(title = "Log requests")
     @NotNull
     @Builder.Default
+    @PluginProperty(group = "main")
     private Property<Boolean> logRequests = Property.ofValue(false);
 
     @Schema(title = "Log responses")
     @NotNull
     @Builder.Default
+    @PluginProperty(group = "main")
     private Property<Boolean> logResponses = Property.ofValue(false);
 
     @Override

--- a/src/main/java/io/kestra/plugin/ai/tool/StdioMcpClient.java
+++ b/src/main/java/io/kestra/plugin/ai/tool/StdioMcpClient.java
@@ -20,6 +20,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
+import io.kestra.core.models.annotations.PluginProperty;
 
 @Getter
 @SuperBuilder
@@ -66,14 +67,17 @@ import lombok.experimental.SuperBuilder;
 public class StdioMcpClient extends AbstractMcpClient {
     @Schema(title = "MCP client command, as a list of command parts")
     @NotNull
+    @PluginProperty(group = "main")
     private Property<List<String>> command;
 
     @Schema(title = "Environment variables")
+    @PluginProperty(group = "execution")
     private Property<Map<String, String>> env;
 
     @Schema(title = "Log events")
     @NotNull
     @Builder.Default
+    @PluginProperty(group = "main")
     private Property<Boolean> logEvents = Property.ofValue(false);
 
     @Override

--- a/src/main/java/io/kestra/plugin/ai/tool/StreamableHttpMcpClient.java
+++ b/src/main/java/io/kestra/plugin/ai/tool/StreamableHttpMcpClient.java
@@ -20,6 +20,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
+import io.kestra.core.models.annotations.PluginProperty;
 
 @Getter
 @SuperBuilder
@@ -67,25 +68,30 @@ import lombok.experimental.SuperBuilder;
 public class StreamableHttpMcpClient extends AbstractMcpClient {
     @Schema(title = "URL of the MCP server")
     @NotNull
+    @PluginProperty(group = "main")
     private Property<String> url;
 
     @Schema(title = "Connection timeout duration")
+    @PluginProperty(group = "execution")
     private Property<Duration> timeout;
 
     @Schema(
         title = "Custom headers",
         description = "Useful, for example, for adding authentication tokens via the `Authorization` header."
     )
+    @PluginProperty(group = "advanced")
     private Property<Map<String, String>> headers;
 
     @Schema(title = "Log requests")
     @NotNull
     @Builder.Default
+    @PluginProperty(group = "main")
     private Property<Boolean> logRequests = Property.ofValue(false);
 
     @Schema(title = "Log responses")
     @NotNull
     @Builder.Default
+    @PluginProperty(group = "main")
     private Property<Boolean> logResponses = Property.ofValue(false);
 
     @Override

--- a/src/main/java/io/kestra/plugin/ai/tool/TavilyWebSearch.java
+++ b/src/main/java/io/kestra/plugin/ai/tool/TavilyWebSearch.java
@@ -22,6 +22,7 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
+import io.kestra.core.models.annotations.PluginProperty;
 
 @Getter
 @SuperBuilder
@@ -68,6 +69,7 @@ import lombok.experimental.SuperBuilder;
 public class TavilyWebSearch extends ToolProvider {
     @Schema(title = "Tavily API Key - you can obtain one from [the Tavily website](https://www.tavily.com/#pricing)")
     @NotNull
+    @PluginProperty(group = "main")
     private Property<String> apiKey;
 
     @Override


### PR DESCRIPTION
## Summary

Add `@PluginProperty(group = "...")` annotations to task properties following the 9-group taxonomy (`main`, `connection`, `source`, `processing`, `execution`, `destination`, `reliability`, `advanced`, `deprecated`).

These annotations drive section grouping in the Kestra NoCode UI editor.

Groups are assigned from a curated CSV of 8,798 property assignments across 925 task types, with heuristic fallback for properties not in the CSV.

Part-of: https://github.com/kestra-io/kestra-ee/issues/6712