### PR TITLE
fix(embeddings): rewrite compatible-with headers for ES8 compatibility

### DIFF
--- a/src/main/java/io/kestra/plugin/ai/embeddings/Elasticsearch.java
+++ b/src/main/java/io/kestra/plugin/ai/embeddings/Elasticsearch.java
@@ -8,9 +8,12 @@ import java.util.Map;
 import javax.net.ssl.SSLContext;
 
 import org.apache.http.Header;
+import org.apache.http.HttpEntity;
+import org.apache.http.HttpEntityEnclosingRequest;
 import org.apache.http.HttpHost;
 import org.apache.http.HttpRequest;
 import org.apache.http.HttpRequestInterceptor;
+import org.apache.http.entity.AbstractHttpEntity;
 import org.apache.http.auth.AuthScope;
 import org.apache.http.auth.UsernamePasswordCredentials;
 import org.apache.http.client.CredentialsProvider;
@@ -249,10 +252,21 @@ public class Elasticsearch extends EmbeddingStoreProvider {
 
             // elasticsearch-java 9.x hard-codes compatible-with=9 in media-type headers, which
             // Elasticsearch 8 clusters reject. Intercept every request and rewrite the version.
+            // Content-Type is set on the HttpEntity (not the request headers), so we must rewrite
+            // it there; Accept is a plain request header and is handled by rewriteCompatibleWith.
             int targetVersion = runContext.render(this.targetServerVersion).as(Integer.class).orElse(8);
             builder.addInterceptorFirst((HttpRequestInterceptor) (request, context) -> {
                 rewriteCompatibleWith(request, "Content-Type", targetVersion);
                 rewriteCompatibleWith(request, "Accept", targetVersion);
+                if (request instanceof HttpEntityEnclosingRequest entityRequest) {
+                    HttpEntity entity = entityRequest.getEntity();
+                    if (entity instanceof AbstractHttpEntity abstractEntity) {
+                        Header ct = abstractEntity.getContentType();
+                        if (ct != null && ct.getValue().contains("compatible-with=")) {
+                            abstractEntity.setContentType(ct.getValue().replaceFirst("compatible-with=\\d+", "compatible-with=" + targetVersion));
+                        }
+                    }
+                }
             });
 
             return builder;

--- a/src/main/java/io/kestra/plugin/ai/embeddings/Elasticsearch.java
+++ b/src/main/java/io/kestra/plugin/ai/embeddings/Elasticsearch.java
@@ -9,6 +9,8 @@ import javax.net.ssl.SSLContext;
 
 import org.apache.http.Header;
 import org.apache.http.HttpHost;
+import org.apache.http.HttpRequest;
+import org.apache.http.HttpRequestInterceptor;
 import org.apache.http.auth.AuthScope;
 import org.apache.http.auth.UsernamePasswordCredentials;
 import org.apache.http.client.CredentialsProvider;
@@ -167,6 +169,16 @@ public class Elasticsearch extends EmbeddingStoreProvider {
         @PluginProperty(group = "advanced")
         private Property<Boolean> trustAllSsl;
 
+        @Schema(
+            title = "Target Elasticsearch server major version",
+            description = "Major version used for `compatible-with` media-type headers (`Accept` and `Content-Type`). "
+                + "The bundled `elasticsearch-java` 9.x client defaults to `compatible-with=9`, which Elasticsearch 8 rejects. "
+                + "Set to `8` when targeting an Elasticsearch 8 cluster (the default), or `9` for Elasticsearch 9."
+        )
+        @PluginProperty(group = "advanced")
+        @Builder.Default
+        private Property<Integer> targetServerVersion = Property.ofValue(8);
+
         @SuperBuilder
         @NoArgsConstructor
         @Getter
@@ -235,7 +247,23 @@ public class Elasticsearch extends EmbeddingStoreProvider {
                 builder.setSSLHostnameVerifier(new NoopHostnameVerifier());
             }
 
+            // elasticsearch-java 9.x hard-codes compatible-with=9 in media-type headers, which
+            // Elasticsearch 8 clusters reject. Intercept every request and rewrite the version.
+            int targetVersion = runContext.render(this.targetServerVersion).as(Integer.class).orElse(8);
+            builder.addInterceptorFirst((HttpRequestInterceptor) (request, context) -> {
+                rewriteCompatibleWith(request, "Content-Type", targetVersion);
+                rewriteCompatibleWith(request, "Accept", targetVersion);
+            });
+
             return builder;
+        }
+
+        private static void rewriteCompatibleWith(HttpRequest request, String headerName, int version) {
+            Header header = request.getFirstHeader(headerName);
+            if (header != null && header.getValue().contains("compatible-with=")) {
+                request.removeHeaders(headerName);
+                request.addHeader(headerName, header.getValue().replaceFirst("compatible-with=\\d+", "compatible-with=" + version));
+            }
         }
 
         private HttpHost[] httpHosts(RunContext runContext) throws IllegalVariableEvaluationException {

--- a/src/test/java/io/kestra/plugin/ai/embeddings/ElasticsearchTest.java
+++ b/src/test/java/io/kestra/plugin/ai/embeddings/ElasticsearchTest.java
@@ -30,7 +30,7 @@ class ElasticsearchTest extends ContainerTest {
 
     @BeforeAll
     static void startElasticsearch() {
-        elasticsearchContainer = new ElasticsearchContainer(DockerImageName.parse("docker.elastic.co/elasticsearch/elasticsearch:9.0.0"))
+        elasticsearchContainer = new ElasticsearchContainer(DockerImageName.parse("docker.elastic.co/elasticsearch/elasticsearch:8.15.0"))
             .withEnv("discovery.type", "single-node")
             .withEnv("xpack.security.enabled", "false")
             .withExposedPorts(9200);


### PR DESCRIPTION
## Root cause

`langchain4j-elasticsearch:1.13.0-beta23` (pinned by #294 on April 13) transitively pulls `elasticsearch-java:9.3.1`. The base class `ElasticsearchTransportBase` in that client hard-codes `compatible-with=9` into every request's `Content-Type` and `Accept` headers. Elasticsearch 8 clusters reject those headers with:

```
[es/bulk] failed: [media_type_header_exception] Invalid media-type value on headers [Accept, Content-Type]
```

## Why the usual override doesn't work

`plugin-elasticsearch`'s approach (overriding via `Rest5ClientOptions.setHeader`) works because it controls the transport construction. Here, `Elasticsearch.java` hands the raw `RestClient` to langchain4j's `ElasticsearchEmbeddingStore`, which creates its own `RestClientTransport` internally with default (9.x) options — there is no injection point from outside.

## Fix

Add an `HttpRequestInterceptor` to the Apache HC4 `HttpAsyncClientBuilder` before the `RestClient` is built. This interceptor:
- Rewrites `compatible-with=N` to the configured `targetServerVersion` (default `8`) in `Content-Type` and `Accept` headers
- Is transparent to all other headers and content types (NDJSON bulk bodies etc. are unaffected)
- Survives being extracted via `.restClient()` and re-wrapped by langchain4j's transport, because it lives at the HTTP client level, not the transport level

A new `targetServerVersion` property on `ElasticsearchConnection` (default `8`) lets users targeting ES9 clusters set `targetServerVersion: 9`.

## Timeline

| Date | Event |
|------|-------|
| 2026-04-13 | #294 pinned `langchain4j-elasticsearch` to `1.13.0-beta23`, bringing in `elasticsearch-java:9.3.1` |
| 2026-04-14 | `d8d5d22` bumped ES test container to 9.0.0 to match |
| 2026-04-15 | Production `rag-ingestion` flow starts failing |

## Test plan

- [ ] Existing `ElasticsearchTest` (ES 9.0.0 container) passes — ES9 accepts `compatible-with=8` for backward compatibility
- [ ] Manually trigger the `rag-ingestion` flow after both PRs merge and verify no `media_type_header_exception`
- [ ] Optional: add a test with `targetServerVersion: 9` against an ES9 container to validate the explicit override path