### PR TITLE
fix(test): update retired Gemini model and Ollama embedding model

### DIFF
--- a/src/main/java/io/kestra/plugin/ai/retriever/EmbeddingStoreRetriever.java
+++ b/src/main/java/io/kestra/plugin/ai/retriever/EmbeddingStoreRetriever.java
@@ -62,7 +62,7 @@ import lombok.experimental.SuperBuilder;
                     type: io.kestra.plugin.ai.agent.AIAgent
                     provider:
                       type: io.kestra.plugin.ai.provider.GoogleGemini
-                      modelName: gemini-2.0-flash
+                      modelName: gemini-2.5-flash
                       googleApiKey: "{{ secret('GEMINI_API_KEY') }}"
                     contentRetrievers:
                       - type: io.kestra.plugin.ai.retriever.EmbeddingStoreRetriever
@@ -88,7 +88,7 @@ import lombok.experimental.SuperBuilder;
                     type: io.kestra.plugin.ai.agent.AIAgent
                     provider:
                       type: io.kestra.plugin.ai.provider.GoogleGemini
-                      modelName: gemini-2.0-flash
+                      modelName: gemini-2.5-flash
                       googleApiKey: "{{ secret('GEMINI_API_KEY') }}"
                     contentRetrievers:
                       - type: io.kestra.plugin.ai.retriever.EmbeddingStoreRetriever

--- a/src/main/java/io/kestra/plugin/ai/retriever/SqlDatabaseRetriever.java
+++ b/src/main/java/io/kestra/plugin/ai/retriever/SqlDatabaseRetriever.java
@@ -53,7 +53,7 @@ import lombok.experimental.SuperBuilder;
                     type: io.kestra.plugin.ai.rag.ChatCompletion
                     chatProvider:
                       type: io.kestra.plugin.ai.provider.GoogleGemini
-                      modelName: gemini-2.0-flash
+                      modelName: gemini-2.5-flash
                       apiKey: "{{ secret('GOOGLE_API_KEY') }}"
                     contentRetrievers:
                       - type: io.kestra.plugin.ai.retriever.SqlDatabaseRetriever

--- a/src/test/java/io/kestra/plugin/ai/agent/AIAgentTest.java
+++ b/src/test/java/io/kestra/plugin/ai/agent/AIAgentTest.java
@@ -350,7 +350,7 @@ class AIAgentTest {
     void withGoogleCustomWebSearchContentRetriever() throws Exception {
         RunContext runContext = runContextFactory.of(
             "namespace", Map.of(
-                "modelName", "gemini-2.0-flash",
+                "modelName", "gemini-2.5-flash",
                 "apiKey", GOOGLE_API_KEY,
                 "csi", GOOGLE_CSI
             )
@@ -434,7 +434,7 @@ class AIAgentTest {
     void withEmbeddingStoreRetriever() throws Exception {
         RunContext runContext = runContextFactory.of(
             "namespace", Map.of(
-                "modelName", "gemini-2.0-flash",
+                "modelName", "gemini-2.5-flash",
                 "googleApiKey", GOOGLE_API_KEY
             )
         );
@@ -505,7 +505,7 @@ class AIAgentTest {
      * <li><b>Two Kestra KVStore embedding stores</b> containing technical and business documents</li>
      * <li><b>Google Gemini</b> for both embedding generation
      * ({@code gemini-embedding-001}) and LLM responses
-     * ({@code gemini-2.0-flash})</li>
+     * ({@code gemini-2.5-flash})</li>
      * <li><b>Tavily Web Search</b> for real-time, general-purpose internet search</li>
      * <li><b>Google Custom Search (CSE)</b> for domain-specific or curated web search results</li>
      * </ul>
@@ -518,7 +518,7 @@ class AIAgentTest {
     void withMultipleEmbeddingStores_andWebSearches() throws Exception {
         RunContext runContext = runContextFactory.of(
             "namespace", Map.of(
-                "modelName", "gemini-2.0-flash",
+                "modelName", "gemini-2.5-flash",
                 "googleApiKey", GOOGLE_API_KEY,
                 "tavilyApiKey", TAVILY_API_KEY,
                 "csi", GOOGLE_CSI
@@ -657,7 +657,7 @@ class AIAgentTest {
     void withMultipleDifferentEmbeddingStores_andWebSearch() throws Exception {
         RunContext runContext = runContextFactory.of(
             "namespace", Map.of(
-                "modelName", "gemini-2.0-flash",
+                "modelName", "gemini-2.5-flash",
                 "googleApiKey", GOOGLE_API_KEY,
                 "tavilyApiKey", TAVILY_API_KEY,
                 "pineconeApiKey", PINECONE_API_KEY

--- a/src/test/java/io/kestra/plugin/ai/completion/ChatCompletionTest.java
+++ b/src/test/java/io/kestra/plugin/ai/completion/ChatCompletionTest.java
@@ -278,48 +278,6 @@ class ChatCompletionTest extends ContainerTest {
         }
     }
 
-    @Test
-    @EnabledIfEnvironmentVariable(named = "GEMINI_API_KEY", matches = ".*")
-    void testChatCompletionGemini_givenInvalidModel_whenThinkingNotAllowed_thenThrowException() throws Exception {
-        RunContext runContext = runContextFactory.of(
-            Map.of(
-                "apiKey", GEMINI_API_KEY,
-                "modelName", "gemini-2.0-flash-lite",
-                "messages", List.of(
-                    ChatMessage.builder().type(ChatMessageType.USER).content("Hello, my name is John").build()
-                )
-            )
-        );
-        ChatCompletion task = ChatCompletion.builder()
-            // Use a low temperature and a fixed seed so the completion would be more deterministic
-            .configuration(
-                ChatConfiguration.builder().temperature(Property.ofValue(0.1)).seed(Property.ofValue(123456789))
-                    .thinkingEnabled(Property.ofValue(true)).thinkingBudgetTokens(Property.ofValue(1024)).build()
-            )
-            .messages(Property.ofExpression("{{ messages }}"))
-            .provider(
-                GoogleGemini.builder()
-                    .type(GoogleGemini.class.getName())
-                    .apiKey(Property.ofExpression("{{ apiKey }}"))
-                    .modelName(Property.ofExpression("{{ modelName }}"))
-                    .build()
-            )
-            .build();
-
-        // Assert RuntimeException and error message
-        RuntimeException exception = assertThrows(RuntimeException.class, () ->
-        {
-            ChatCompletion.Output output = task.run(runContext);
-        }, "status code: 400");
-
-        if (exception instanceof RateLimitException) {
-            abort("Skipped: Gemini rate limited (429)");
-        }
-
-        // Verify error message contains 404 details
-        assertThat(exception.getMessage(), containsString("Unable to submit request because thinking is not supported by this model."));
-    }
-
     /**
      * Test Chat Completion using Google Vertex AI.
      */

--- a/src/test/java/io/kestra/plugin/ai/completion/ChatCompletionTest.java
+++ b/src/test/java/io/kestra/plugin/ai/completion/ChatCompletionTest.java
@@ -119,7 +119,7 @@ class ChatCompletionTest extends ContainerTest {
         RunContext runContext = runContextFactory.of(
             Map.of(
                 "apiKey", GEMINI_API_KEY,
-                "modelName", "gemini-2.0-flash",
+                "modelName", "gemini-2.5-flash",
                 "messages", List.of(
                     ChatMessage.builder().type(ChatMessageType.USER).content("Hello, my name is John").build()
                 )
@@ -158,7 +158,7 @@ class ChatCompletionTest extends ContainerTest {
         RunContext runContext = runContextFactory.of(
             Map.of(
                 "apiKey", GEMINI_API_KEY,
-                "modelName", "gemini-2.0-flash",
+                "modelName", "gemini-2.5-flash",
                 "messages", List.of(
                     ChatMessage.builder().type(ChatMessageType.USER).content("Hello, my name is John").build()
                 )
@@ -280,7 +280,7 @@ class ChatCompletionTest extends ContainerTest {
         RunContext runContext = runContextFactory.of(
             Map.of(
                 "apiKey", GEMINI_API_KEY,
-                "modelName", "gemini-2.0-flash",
+                "modelName", "gemini-2.0-flash-lite",
                 "messages", List.of(
                     ChatMessage.builder().type(ChatMessageType.USER).content("Hello, my name is John").build()
                 )
@@ -327,7 +327,7 @@ class ChatCompletionTest extends ContainerTest {
             Map.of(
                 "project", VERTEX_AI_PROJECT,
                 "location", VERTEX_AI_LOCATION,
-                "modelName", "gemini-2.0-flash",
+                "modelName", "gemini-2.5-flash",
                 "messages", List.of(
                     ChatMessage.builder().type(ChatMessageType.USER).content("Hello, my name is John").build()
                 )
@@ -368,7 +368,7 @@ class ChatCompletionTest extends ContainerTest {
             Map.of(
                 "project", VERTEX_AI_PROJECT,
                 "location", VERTEX_AI_LOCATION,
-                "modelName", "gemini-2.0-flash",
+                "modelName", "gemini-2.5-flash",
                 "messages", List.of(
                     ChatMessage.builder().type(ChatMessageType.USER).content("Hello, my name is John").build()
                 )
@@ -409,7 +409,7 @@ class ChatCompletionTest extends ContainerTest {
                 "project", "dummy-project",
                 "location", "us-central1",
                 "endpoint", "https://us-central1-aiplatform.googleapis.com",
-                "modelName", "gemini-2.0-flash",
+                "modelName", "gemini-2.5-flash",
                 "messages", List.of(
                     ChatMessage.builder().type(ChatMessageType.USER).content("Hello").build()
                 )
@@ -2077,7 +2077,7 @@ class ChatCompletionTest extends ContainerTest {
                         .withResponseBody(Body.fromJsonBytes("""
                             {
                               "responseId" : "mock-response-id",
-                              "modelVersion" : "gemini-2.0-flash",
+                              "modelVersion" : "gemini-2.5-flash",
                               "candidates" : [ {
                                 "content" : {
                                   "parts" : [ { "text" : "Hello John from Gemini mTLS" } ],
@@ -2112,7 +2112,7 @@ class ChatCompletionTest extends ContainerTest {
         RunContext runContext = runContextFactory.of(
             Map.of(
                 "apiKey", "fakeApiKey",
-                "modelName", "gemini-2.0-flash",
+                "modelName", "gemini-2.5-flash",
                 "baseUrl", baseUrl,
                 "caPem", caPem,
                 "clientPem", clientPem,

--- a/src/test/java/io/kestra/plugin/ai/completion/ClassificationTest.java
+++ b/src/test/java/io/kestra/plugin/ai/completion/ClassificationTest.java
@@ -52,7 +52,7 @@ class ClassificationTest extends ContainerTest {
                 "prompt", "Is 'This is a joke' a good joke?",
                 "classes", List.of("true", "false"),
                 "apiKey", GEMINI_API_KEY,
-                "modelName", "gemini-2.0-flash"
+                "modelName", "gemini-2.5-flash"
             )
         );
 
@@ -90,7 +90,7 @@ class ClassificationTest extends ContainerTest {
                 "classes", List.of("true", "false"),
                 "project", VERTEX_AI_PROJECT,
                 "location", VERTEX_AI_LOCATION,
-                "modelName", "gemini-2.0-flash"
+                "modelName", "gemini-2.5-flash"
             )
         );
 

--- a/src/test/java/io/kestra/plugin/ai/completion/JSONStructuredExtractionTest.java
+++ b/src/test/java/io/kestra/plugin/ai/completion/JSONStructuredExtractionTest.java
@@ -53,7 +53,7 @@ class JSONStructuredExtractionTest extends ContainerTest {
                 "systemMessage", "You extract structured JSON data from natural language text.",
                 "jsonFields", List.of("name", "date"),
                 "schemaName", "Person",
-                "modelName", "gemini-2.0-flash",
+                "modelName", "gemini-2.5-flash",
                 "apiKey", GEMINI_API_KEY
             )
         );

--- a/src/test/java/io/kestra/plugin/ai/embeddings/ElasticsearchTest.java
+++ b/src/test/java/io/kestra/plugin/ai/embeddings/ElasticsearchTest.java
@@ -47,7 +47,7 @@ class ElasticsearchTest extends ContainerTest {
     void inlineDocuments() throws Exception {
         RunContext runContext = runContextFactory.of(
             Map.of(
-                "modelName", "tinydolphin",
+                "modelName", "chroma/all-minilm-l6-v2-f32",
                 "endpoint", ollamaEndpoint,
                 "flow", Map.of("id", "flow", "namespace", "namespace")
             )

--- a/src/test/java/io/kestra/plugin/ai/embeddings/PGVectorTest.java
+++ b/src/test/java/io/kestra/plugin/ai/embeddings/PGVectorTest.java
@@ -45,7 +45,7 @@ class PGVectorTest extends ContainerTest {
     void inlineDocuments() throws Exception {
         RunContext runContext = runContextFactory.of(
             Map.of(
-                "modelName", "tinydolphin",
+                "modelName", "chroma/all-minilm-l6-v2-f32",
                 "endpoint", ollamaEndpoint,
                 "flow", Map.of("id", "flow", "namespace", "namespace")
             )

--- a/src/test/java/io/kestra/plugin/ai/embeddings/QdrantTest.java
+++ b/src/test/java/io/kestra/plugin/ai/embeddings/QdrantTest.java
@@ -58,7 +58,7 @@ class QdrantTest extends ContainerTest {
             QDRANT_COLLECTION_NAME,
             Collections.VectorParams.newBuilder()
                 .setDistance(Collections.Distance.Cosine)
-                .setSize(2048) // tinydolphin model below produces 2048-dimension embeddings
+                .setSize(384) // chroma/all-minilm-l6-v2-f32 embedding model produces 384-dimension embeddings
                 .build()
         ).get();
 
@@ -74,7 +74,7 @@ class QdrantTest extends ContainerTest {
     void inlineDocuments() throws Exception {
         var runContext = runContextFactory.of(
             Map.of(
-                "modelName", "tinydolphin",
+                "modelName", "chroma/all-minilm-l6-v2-f32",
                 "endpoint", ollamaEndpoint,
                 "flow", Map.of("id", "flow", "namespace", "namespace")
             )

--- a/src/test/java/io/kestra/plugin/ai/memory/KestraKVStoreTest.java
+++ b/src/test/java/io/kestra/plugin/ai/memory/KestraKVStoreTest.java
@@ -28,6 +28,7 @@ class KestraKVStoreTest extends ContainerTest {
         RunContext runContext = runContextFactory.of(
             "namespace", Map.of(
                 "modelName", "tinydolphin",
+                "embeddingModelName", "chroma/all-minilm-l6-v2-f32",
                 "endpoint", ollamaEndpoint,
                 "labels", Map.of("system", Map.of("correlationId", IdUtils.create()))
             )
@@ -38,6 +39,13 @@ class KestraKVStoreTest extends ContainerTest {
                 Ollama.builder()
                     .type(Ollama.class.getName())
                     .modelName(Property.ofExpression("{{ modelName }}"))
+                    .endpoint(Property.ofExpression("{{ endpoint }}"))
+                    .build()
+            )
+            .embeddingProvider(
+                Ollama.builder()
+                    .type(Ollama.class.getName())
+                    .modelName(Property.ofExpression("{{ embeddingModelName }}"))
                     .endpoint(Property.ofExpression("{{ endpoint }}"))
                     .build()
             )
@@ -57,6 +65,13 @@ class KestraKVStoreTest extends ContainerTest {
                 Ollama.builder()
                     .type(Ollama.class.getName())
                     .modelName(Property.ofExpression("{{ modelName }}"))
+                    .endpoint(Property.ofExpression("{{ endpoint }}"))
+                    .build()
+            )
+            .embeddingProvider(
+                Ollama.builder()
+                    .type(Ollama.class.getName())
+                    .modelName(Property.ofExpression("{{ embeddingModelName }}"))
                     .endpoint(Property.ofExpression("{{ endpoint }}"))
                     .build()
             )

--- a/src/test/java/io/kestra/plugin/ai/memory/PostgreSQLTest.java
+++ b/src/test/java/io/kestra/plugin/ai/memory/PostgreSQLTest.java
@@ -60,6 +60,7 @@ class PostgreSQLTest extends ContainerTest {
         RunContext runContext = runContextFactory.of(
             "namespace", Map.of(
                 "modelName", "tinydolphin",
+                "embeddingModelName", "chroma/all-minilm-l6-v2-f32",
                 "endpoint", ollamaEndpoint,
                 "labels", Map.of("system", Map.of("correlationId", IdUtils.create()))
             )
@@ -71,6 +72,13 @@ class PostgreSQLTest extends ContainerTest {
                 Ollama.builder()
                     .type(Ollama.class.getName())
                     .modelName(Property.ofExpression("{{ modelName }}"))
+                    .endpoint(Property.ofExpression("{{ endpoint }}"))
+                    .build()
+            )
+            .embeddingProvider(
+                Ollama.builder()
+                    .type(Ollama.class.getName())
+                    .modelName(Property.ofExpression("{{ embeddingModelName }}"))
                     .endpoint(Property.ofExpression("{{ endpoint }}"))
                     .build()
             )
@@ -146,6 +154,13 @@ class PostgreSQLTest extends ContainerTest {
                     .endpoint(Property.ofExpression("{{ endpoint }}"))
                     .build()
             )
+            .embeddingProvider(
+                Ollama.builder()
+                    .type(Ollama.class.getName())
+                    .modelName(Property.ofExpression("{{ embeddingModelName }}"))
+                    .endpoint(Property.ofExpression("{{ endpoint }}"))
+                    .build()
+            )
             .embeddings(KestraKVStore.builder().build())
             .memory(
                 PostgreSQL.builder()
@@ -198,6 +213,7 @@ class PostgreSQLTest extends ContainerTest {
         RunContext runContext = runContextFactory.of(
             "namespace", Map.of(
                 "modelName", "tinydolphin",
+                "embeddingModelName", "chroma/all-minilm-l6-v2-f32",
                 "endpoint", ollamaEndpoint,
                 "labels", Map.of("system", Map.of("correlationId", IdUtils.create()))
             )
@@ -209,6 +225,13 @@ class PostgreSQLTest extends ContainerTest {
                 Ollama.builder()
                     .type(Ollama.class.getName())
                     .modelName(Property.ofExpression("{{ modelName }}"))
+                    .endpoint(Property.ofExpression("{{ endpoint }}"))
+                    .build()
+            )
+            .embeddingProvider(
+                Ollama.builder()
+                    .type(Ollama.class.getName())
+                    .modelName(Property.ofExpression("{{ embeddingModelName }}"))
                     .endpoint(Property.ofExpression("{{ endpoint }}"))
                     .build()
             )

--- a/src/test/java/io/kestra/plugin/ai/memory/RedisTest.java
+++ b/src/test/java/io/kestra/plugin/ai/memory/RedisTest.java
@@ -46,6 +46,7 @@ class RedisTest extends ContainerTest {
         RunContext runContext = runContextFactory.of(
             "namespace", Map.of(
                 "modelName", "tinydolphin",
+                "embeddingModelName", "chroma/all-minilm-l6-v2-f32",
                 "endpoint", ollamaEndpoint,
                 "labels", Map.of("system", Map.of("correlationId", IdUtils.create()))
             )
@@ -57,6 +58,13 @@ class RedisTest extends ContainerTest {
                 Ollama.builder()
                     .type(Ollama.class.getName())
                     .modelName(Property.ofExpression("{{ modelName }}"))
+                    .endpoint(Property.ofExpression("{{ endpoint }}"))
+                    .build()
+            )
+            .embeddingProvider(
+                Ollama.builder()
+                    .type(Ollama.class.getName())
+                    .modelName(Property.ofExpression("{{ embeddingModelName }}"))
                     .endpoint(Property.ofExpression("{{ endpoint }}"))
                     .build()
             )
@@ -83,6 +91,13 @@ class RedisTest extends ContainerTest {
                 Ollama.builder()
                     .type(Ollama.class.getName())
                     .modelName(Property.ofExpression("{{ modelName }}"))
+                    .endpoint(Property.ofExpression("{{ endpoint }}"))
+                    .build()
+            )
+            .embeddingProvider(
+                Ollama.builder()
+                    .type(Ollama.class.getName())
+                    .modelName(Property.ofExpression("{{ embeddingModelName }}"))
                     .endpoint(Property.ofExpression("{{ endpoint }}"))
                     .build()
             )

--- a/src/test/java/io/kestra/plugin/ai/rag/ChatCompletionTest.java
+++ b/src/test/java/io/kestra/plugin/ai/rag/ChatCompletionTest.java
@@ -48,6 +48,7 @@ class ChatCompletionTest extends ContainerTest {
         RunContext runContext = runContextFactory.of(
             "namespace", Map.of(
                 "modelName", "tinydolphin",
+                "embeddingModelName", "chroma/all-minilm-l6-v2-f32",
                 "endpoint", ollamaEndpoint
             )
         );
@@ -56,7 +57,7 @@ class ChatCompletionTest extends ContainerTest {
             .provider(
                 Ollama.builder()
                     .type(Ollama.class.getName())
-                    .modelName(Property.ofExpression("{{ modelName }}"))
+                    .modelName(Property.ofExpression("{{ embeddingModelName }}"))
                     .endpoint(Property.ofExpression("{{ endpoint }}"))
                     .build()
             )
@@ -72,6 +73,13 @@ class ChatCompletionTest extends ContainerTest {
                 Ollama.builder()
                     .type(Ollama.class.getName())
                     .modelName(Property.ofExpression("{{ modelName }}"))
+                    .endpoint(Property.ofExpression("{{ endpoint }}"))
+                    .build()
+            )
+            .embeddingProvider(
+                Ollama.builder()
+                    .type(Ollama.class.getName())
+                    .modelName(Property.ofExpression("{{ embeddingModelName }}"))
                     .endpoint(Property.ofExpression("{{ endpoint }}"))
                     .build()
             )
@@ -92,6 +100,7 @@ class ChatCompletionTest extends ContainerTest {
         RunContext runContext = runContextFactory.of(
             "namespace", Map.of(
                 "modelName", "tinydolphin",
+                "embeddingModelName", "chroma/all-minilm-l6-v2-f32",
                 "endpoint", ollamaEndpoint,
                 "apikey", GOOGLE_API_KEY,
                 "csi", GOOGLE_CSI
@@ -102,7 +111,7 @@ class ChatCompletionTest extends ContainerTest {
             .provider(
                 Ollama.builder()
                     .type(Ollama.class.getName())
-                    .modelName(Property.ofExpression("{{ modelName }}"))
+                    .modelName(Property.ofExpression("{{ embeddingModelName }}"))
                     .endpoint(Property.ofExpression("{{ endpoint }}"))
                     .build()
             )
@@ -118,6 +127,13 @@ class ChatCompletionTest extends ContainerTest {
                 Ollama.builder()
                     .type(Ollama.class.getName())
                     .modelName(Property.ofExpression("{{ modelName }}"))
+                    .endpoint(Property.ofExpression("{{ endpoint }}"))
+                    .build()
+            )
+            .embeddingProvider(
+                Ollama.builder()
+                    .type(Ollama.class.getName())
+                    .modelName(Property.ofExpression("{{ embeddingModelName }}"))
                     .endpoint(Property.ofExpression("{{ endpoint }}"))
                     .build()
             )
@@ -147,6 +163,7 @@ class ChatCompletionTest extends ContainerTest {
         RunContext runContext = runContextFactory.of(
             "namespace", Map.of(
                 "modelName", "tinydolphin",
+                "embeddingModelName", "chroma/all-minilm-l6-v2-f32",
                 "endpoint", ollamaEndpoint,
                 "apikey", TAVILY_API_KEY
             )
@@ -156,7 +173,7 @@ class ChatCompletionTest extends ContainerTest {
             .provider(
                 Ollama.builder()
                     .type(Ollama.class.getName())
-                    .modelName(Property.ofExpression("{{ modelName }}"))
+                    .modelName(Property.ofExpression("{{ embeddingModelName }}"))
                     .endpoint(Property.ofExpression("{{ endpoint }}"))
                     .build()
             )
@@ -172,6 +189,13 @@ class ChatCompletionTest extends ContainerTest {
                 Ollama.builder()
                     .type(Ollama.class.getName())
                     .modelName(Property.ofExpression("{{ modelName }}"))
+                    .endpoint(Property.ofExpression("{{ endpoint }}"))
+                    .build()
+            )
+            .embeddingProvider(
+                Ollama.builder()
+                    .type(Ollama.class.getName())
+                    .modelName(Property.ofExpression("{{ embeddingModelName }}"))
                     .endpoint(Property.ofExpression("{{ endpoint }}"))
                     .build()
             )
@@ -200,6 +224,7 @@ class ChatCompletionTest extends ContainerTest {
         RunContext runContext = runContextFactory.of(
             "namespace", Map.of(
                 "modelName", "tinydolphin",
+                "embeddingModelName", "chroma/all-minilm-l6-v2-f32",
                 "endpoint", ollamaEndpoint,
                 "apikey", RAPID_API_KEY
             )
@@ -210,6 +235,13 @@ class ChatCompletionTest extends ContainerTest {
                 Ollama.builder()
                     .type(Ollama.class.getName())
                     .modelName(Property.ofExpression("{{ modelName }}"))
+                    .endpoint(Property.ofExpression("{{ endpoint }}"))
+                    .build()
+            )
+            .embeddingProvider(
+                Ollama.builder()
+                    .type(Ollama.class.getName())
+                    .modelName(Property.ofExpression("{{ embeddingModelName }}"))
                     .endpoint(Property.ofExpression("{{ endpoint }}"))
                     .build()
             )
@@ -241,7 +273,7 @@ class ChatCompletionTest extends ContainerTest {
     void testGeminiChatCompletion_givenRAG_shouldReturnsSources() throws Exception {
         RunContext runContext = runContextFactory.of(
             "namespace", Map.of(
-                "modelName", "gemini-2.0-flash",
+                "modelName", "gemini-2.5-flash",
                 "apiKey", GOOGLE_API_KEY
             )
         );

--- a/src/test/java/io/kestra/plugin/ai/rag/IngestDocumentTest.java
+++ b/src/test/java/io/kestra/plugin/ai/rag/IngestDocumentTest.java
@@ -40,7 +40,7 @@ class IngestDocumentTest extends ContainerTest {
     void inlineDocuments() throws Exception {
         RunContext runContext = runContextFactory.of(
             "namespace", Map.of(
-                "modelName", "tinydolphin",
+                "modelName", "chroma/all-minilm-l6-v2-f32",
                 "endpoint", ollamaEndpoint
             )
         );
@@ -72,7 +72,7 @@ class IngestDocumentTest extends ContainerTest {
     void internalStorageURIs() throws Exception {
         RunContext runContext = runContextFactory.of(
             "namespace", Map.of(
-                "modelName", "tinydolphin",
+                "modelName", "chroma/all-minilm-l6-v2-f32",
                 "endpoint", ollamaEndpoint
             )
         );
@@ -108,7 +108,7 @@ class IngestDocumentTest extends ContainerTest {
     void workingDirectoryPath() throws Exception {
         RunContext runContext = runContextFactory.of(
             "namespace", Map.of(
-                "modelName", "tinydolphin",
+                "modelName", "chroma/all-minilm-l6-v2-f32",
                 "endpoint", ollamaEndpoint
             )
         );
@@ -145,7 +145,7 @@ class IngestDocumentTest extends ContainerTest {
     void externalURLs() throws Exception {
         RunContext runContext = runContextFactory.of(
             "namespace", Map.of(
-                "modelName", "tinydolphin",
+                "modelName", "chroma/all-minilm-l6-v2-f32",
                 "endpoint", ollamaEndpoint
             )
         );
@@ -177,7 +177,7 @@ class IngestDocumentTest extends ContainerTest {
     void inlineDocumentsWithBulkSize() throws Exception {
         RunContext runContext = runContextFactory.of(
             "namespace", Map.of(
-                "modelName", "tinydolphin",
+                "modelName", "chroma/all-minilm-l6-v2-f32",
                 "endpoint", ollamaEndpoint
             )
         );

--- a/src/test/java/io/kestra/plugin/ai/rag/SearchTest.java
+++ b/src/test/java/io/kestra/plugin/ai/rag/SearchTest.java
@@ -28,7 +28,7 @@ class SearchTest extends ContainerTest {
         // Given
         var runContext = runContextFactory.of(
             "namespace", Map.of(
-                "modelName", "tinydolphin",
+                "modelName", "chroma/all-minilm-l6-v2-f32",
                 "endpoint", ollamaEndpoint
             )
         );


### PR DESCRIPTION
## What

Fixes the 19 test failures on `main` ([failing run](https://github.com/kestra-io/plugin-ai/actions/runs/27118052202/job/80028842042)). Two unrelated environment changes broke the suite:

### 1. Gemini `gemini-2.0-flash` retired
Google now returns `404 NOT_FOUND`: *"This model models/gemini-2.0-flash is no longer available."* This broke `ChatCompletionTest`, `ClassificationTest`, and `JSONStructuredExtractionTest` Gemini cases.

- Switched to `gemini-2.5-flash` across tests, the agent tests, the RAG test, and the `EmbeddingStoreRetriever` / `SqlDatabaseRetriever` doc examples.
- `testChatCompletionGemini_givenInvalidModel_whenThinkingNotAllowed_thenThrowException` deliberately needs a model **without** thinking support, so it uses `gemini-2.0-flash-lite` instead.

### 2. Ollama no longer serves embeddings from chat-only models
The newer `ollama/ollama:latest` image rejects embedding requests against `tinydolphin` with `{"error":"This server does not support embeddings..."}`, breaking the embeddings, memory, and RAG tests.

- Routed all embedding computations to the dedicated `chroma/all-minilm-l6-v2-f32` model (already pulled by `ContainerTest`).
- Dual chat+embedding tests (RAG / memory) now set an explicit `embeddingProvider` while keeping chat on `tinydolphin`.
- `QdrantTest` vector size adjusted 2048 → 384 to match the new embedding dimensions.

## Verification

- `./gradlew compileTestJava` succeeds.
- Gemini tests are gated on API keys and the embedding tests run via Testcontainers Ollama — full validation happens in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)