### PR TITLE
fix(provider): don't send thinkingBudget=0 to Gemini 3 models

### DIFF
--- a/src/main/java/io/kestra/plugin/ai/provider/GoogleGemini.java
+++ b/src/main/java/io/kestra/plugin/ai/provider/GoogleGemini.java
@@ -4,6 +4,7 @@ import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.regex.Pattern;
 
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 
@@ -46,8 +47,10 @@ import io.kestra.core.models.annotations.PluginProperty;
         them to the conversation history for every follow-up request (`sendThinking` is always enabled), preventing \
         the `400 INVALID_ARGUMENT – Function call is missing a thought_signature` error.
 
-        In addition, thinking is disabled by default (`thinkingBudget = 0`) to reduce token usage, \
-        unless `thinkingEnabled: true` or `thinkingBudgetTokens > 0` is explicitly set."""
+        In addition, on Gemini 2.x models thinking is disabled by default (`thinkingBudget = 0`) to reduce \
+        token usage, unless `thinkingEnabled: true` or `thinkingBudgetTokens > 0` is explicitly set. \
+        Gemini 3 models cannot have thinking turned off, so no thinking budget is sent for them by default \
+        and the model applies its own; set `thinkingBudgetTokens` to cap it."""
 )
 @Plugin(
     examples = {
@@ -119,6 +122,7 @@ import io.kestra.core.models.annotations.PluginProperty;
     aliases = "io.kestra.plugin.langchain4j.provider.GoogleGemini"
 )
 public class GoogleGemini extends ModelProvider {
+    private static final Pattern GEMINI_MAJOR_VERSION = Pattern.compile("gemini-(\\d+)");
 
     @Schema(
         title = "API Key",
@@ -227,17 +231,34 @@ public class GoogleGemini extends ModelProvider {
     GeminiThinkingConfig getThinkingConfig(final ChatConfiguration configuration, final RunContext runContext) throws IllegalVariableEvaluationException {
         var enabled = runContext.render(configuration.getThinkingEnabled()).as(Boolean.class).orElse(false);
         var maxTokens = runContext.render(configuration.getThinkingBudgetTokens()).as(Integer.class).orElse(null);
-        // Default to 0 when thinking is not explicitly requested.
-        // Gemini thinking models (e.g. gemini-3.5-flash) enable thinking when budget is null,
-        // and LangChain4j does not yet propagate thought_signatures in multi-turn conversations,
-        // causing tool calls to fail with 400 INVALID_ARGUMENT.
+
         if (!enabled && maxTokens == null) {
+            // Gemini 2.x thinking models turn thinking on when no budget is given, so we pin the budget
+            // to 0 to keep token usage down.
+            // Gemini 3 models cannot have thinking turned off: they reject `thinkingBudget: 0` with
+            // 400 INVALID_ARGUMENT.  For those, send no thinking configuration at all and let the model
+            // apply its own default.  Thought signatures are still handled: `returnThinking` captures
+            // them and `sendThinking` re-attaches them on follow-up requests.
+            if (thinkingCannotBeDisabled(runContext)) {
+                return null;
+            }
             maxTokens = 0;
         }
+
         return GeminiThinkingConfig.builder()
             .includeThoughts(enabled)
             .thinkingBudget(maxTokens)
             .build();
+    }
+
+    /**
+     * Gemini 3 and later are thinking-only models: they reject a `thinkingBudget` of 0.
+     * Model names that don't carry a recognisable Gemini version are treated as pre-3.
+     */
+    private boolean thinkingCannotBeDisabled(final RunContext runContext) throws IllegalVariableEvaluationException {
+        var rModelName = runContext.render(this.getModelName()).as(String.class).orElse("");
+        var matcher = GEMINI_MAJOR_VERSION.matcher(rModelName);
+        return matcher.find() && Integer.parseInt(matcher.group(1)) >= 3;
     }
 
     @Getter

--- a/src/test/java/io/kestra/plugin/ai/completion/ChatCompletionTest.java
+++ b/src/test/java/io/kestra/plugin/ai/completion/ChatCompletionTest.java
@@ -164,7 +164,10 @@ class ChatCompletionTest extends ContainerTest {
         RunContext runContext = runContextFactory.of(
             Map.of(
                 "apiKey", GEMINI_API_KEY,
-                "modelName", "gemini-3.5-flash-lite",
+                // Deliberately a Gemini 2.x model: thinking tokens count towards maxOutputTokens, and
+                // Gemini 3 models cannot have thinking turned off, so a budget of 10 output tokens would
+                // be spent thinking and never reach the answer.  Only on 2.x can we assert the cap exactly.
+                "modelName", "gemini-2.5-flash",
                 "messages", List.of(
                     ChatMessage.builder().type(ChatMessageType.USER).content("Hello, my name is John").build()
                 )

--- a/src/test/java/io/kestra/plugin/ai/provider/GoogleGeminiTest.java
+++ b/src/test/java/io/kestra/plugin/ai/provider/GoogleGeminiTest.java
@@ -1,5 +1,6 @@
 package io.kestra.plugin.ai.provider;
 
+import java.util.List;
 import java.util.Map;
 
 import org.junit.jupiter.api.Test;
@@ -53,16 +54,16 @@ class GoogleGeminiTest {
     }
 
     @Test
-    void getThinkingConfig_shouldDefaultBudgetToZeroWhenNoConfigSet() throws Exception {
-        // Issue #324: gemini-3.5-flash attaches thought_signatures to function-call parts.
+    void getThinkingConfig_shouldDefaultBudgetToZeroOnGemini2WhenNoConfigSet() throws Exception {
+        // Issue #324: thinking models attach thought_signatures to function-call parts.
         // Primary fix: returnThinking defaults to true (to capture the signature) and
         // sendThinking is always enabled (to re-attach it in follow-up requests), preventing
         // the 400 INVALID_ARGUMENT error from LangChain4j dropping the signature.
-        // Belt-and-suspenders: thinkingBudget defaults to 0 to minimise thinking overhead.
+        // Belt-and-suspenders: on Gemini 2.x, thinkingBudget defaults to 0 to minimise thinking overhead.
         var runContext = runContextFactory.of(Map.of());
         var provider = GoogleGemini.builder()
             .type(GoogleGemini.class.getName())
-            .modelName(Property.ofValue("gemini-3.5-flash"))
+            .modelName(Property.ofValue("gemini-2.5-flash"))
             .apiKey(Property.ofValue("placeholder"))
             .build();
         var config = ChatConfiguration.empty();
@@ -74,7 +75,28 @@ class GoogleGeminiTest {
     }
 
     @Test
+    void getThinkingConfig_shouldSendNoConfigOnGemini3AndLaterWhenNoConfigSet() throws Exception {
+        // Gemini 3+ cannot have thinking turned off and rejects `thinkingBudget: 0` with
+        // 400 INVALID_ARGUMENT, so no thinking configuration must be sent at all.
+        var runContext = runContextFactory.of(Map.of());
+        var config = ChatConfiguration.empty();
+
+        for (var modelName : List.of("gemini-3.5-flash-lite", "gemini-3-pro-preview", "models/gemini-4-flash")) {
+            var provider = GoogleGemini.builder()
+                .type(GoogleGemini.class.getName())
+                .modelName(Property.ofValue(modelName))
+                .apiKey(Property.ofValue("placeholder"))
+                .build();
+
+            assertThat(provider.getThinkingConfig(config, runContext))
+                .as("thinking config for %s", modelName)
+                .isNull();
+        }
+    }
+
+    @Test
     void getThinkingConfig_shouldRespectExplicitBudget() throws Exception {
+        // On a Gemini 3 model an explicit budget is still sent: only the implicit 0 default is skipped.
         var runContext = runContextFactory.of(Map.of());
         var provider = GoogleGemini.builder()
             .type(GoogleGemini.class.getName())


### PR DESCRIPTION
## What

Gemini 3 models are thinking-only: they reject `thinkingBudget: 0` with `400 INVALID_ARGUMENT`. `GoogleGemini.getThinkingConfig()` pins the budget to `0` whenever the user hasn't explicitly asked for thinking, so **every** Gemini 3 call made with a default `ChatConfiguration` fails.

When no thinking is explicitly requested:
- **Gemini 2.x** — unchanged, still pins `thinkingBudget: 0` to keep token usage down.
- **Gemini 3+** — send no thinking configuration at all and let the model apply its own default.

An explicit `thinkingEnabled` / `thinkingBudgetTokens` still passes through on every version — that path was already proven to work against `gemini-3.5-flash-lite`.

Thought signatures are unaffected: `returnThinking` captures them and `sendThinking` re-attaches them on follow-up requests, which is the actual fix from #325.

## Why

CI has been red since 2026-08-25. #399 bumped the tests from `gemini-2.5-flash` to `gemini-3.5-flash-lite`, which exposed the bug:

| run | date | sha | result |
|---|---|---|---|
| 1523 | 08-24 | `977493c` | ok |
| 1528 | 08-25 | `d44e89f` | FAIL |
| … | | | FAIL every scheduled run since |

Same 5 tests every run, all with the identical `400 INVALID_ARGUMENT`:

```
ChatCompletionTest › testChatCompletionGemini()
ChatCompletionTest › testChatCompletionGemini_givenMaxTokenInput_shouldRespectMaxOutputTokens()
ClassificationTest › testClassificationGemini()
JSONStructuredExtractionTest › testJSONStructuredGemini()
KestraTaskTest › httpRequest()
```

The discriminator: the only two Gemini tests that stayed green are the two that explicitly set `thinkingEnabled: true` + `thinkingBudgetTokens: 1024`, so the `budget = 0` default never applied to them.

**This is not just test breakage** — it shipped. Anyone on `1.16.x` pointing the provider at a Gemini 3 model with a default configuration gets a 400. Worth backporting.

## Tests

- `GoogleGeminiTest.getThinkingConfig_shouldDefaultBudgetToZeroWhenNoConfigSet` encoded the bug (asserted budget `0` on `gemini-3.5-flash`) — retargeted to `gemini-2.5-flash`.
- New `getThinkingConfig_shouldSendNoConfigOnGemini3AndLaterWhenNoConfigSet` covers `gemini-3.5-flash-lite`, `gemini-3-pro-preview` and the prefixed `models/gemini-4-flash` form.
- `testChatCompletionGemini_givenMaxTokenInput_shouldRespectMaxOutputTokens` moved back to `gemini-2.5-flash`. Thinking tokens count against `maxOutputTokens` and Gemini 3 can't turn thinking off, so a 10-token cap would be spent thinking and never reach the answer — that test's premise is incompatible with any Gemini 3 model, fix or no fix.

Locally: `GoogleGeminiTest` 7/7, full `provider` package 22 passed / 1 skipped. The four remaining integration tests need a `GEMINI_API_KEY` and are verified by CI on this PR.

## Note

Gemini 3 users now pay for the model's default thinking where the plugin previously tried to suppress it. langchain4j 1.19.0 exposes Gemini 3's `thinkingLevel` (MINIMAL/LOW/MEDIUM/HIGH), which would give back a cheap default — left out here as it's a new user-facing plugin property, and I'd want to confirm which levels each Gemini 3 model accepts before defaulting to one. Guessing that is what caused this bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)