### PR TITLE
fix(tool): report Kestra API auth failures as such instead of a missing flow

### DIFF
--- a/src/main/java/io/kestra/plugin/ai/agent/AIAgent.java
+++ b/src/main/java/io/kestra/plugin/ai/agent/AIAgent.java
@@ -106,6 +106,10 @@ import static io.kestra.core.utils.Rethrow.throwFunction;
                 tasks:
                   - id: multilingual_agent
                     type: io.kestra.plugin.ai.agent.AIAgent
+                    provider:
+                      type: io.kestra.plugin.ai.provider.GoogleGemini
+                      modelName: gemini-3.5-flash-lite
+                      apiKey: "{{ secret('GEMINI_API_KEY') }}"
                     systemMessage: |
                       You are a precise technical assistant.
                       Produce a {{ inputs.summary_length }} summary in {{ inputs.language }}.
@@ -120,15 +124,11 @@ import static io.kestra.core.utils.Rethrow.throwFunction;
 
                   - id: english_brevity
                     type: io.kestra.plugin.ai.agent.AIAgent
+                    provider:
+                      type: io.kestra.plugin.ai.provider.GoogleGemini
+                      modelName: gemini-3.5-flash-lite
+                      apiKey: "{{ secret('GEMINI_API_KEY') }}"
                     prompt: Generate exactly 1 sentence English summary of "{{ outputs.multilingual_agent.textOutput }}"
-
-                pluginDefaults:
-                  - type: io.kestra.plugin.ai.agent.AIAgent
-                    values:
-                      provider:
-                        type: io.kestra.plugin.ai.provider.GoogleGemini
-                        modelName: gemini-3.5-flash-lite
-                        apiKey: "{{ secret('GEMINI_API_KEY') }}"
                 """
         ),
         @Example(
@@ -168,24 +168,29 @@ import static io.kestra.core.utils.Rethrow.throwFunction;
                 tasks:
                   - id: first_agent
                     type: io.kestra.plugin.ai.agent.AIAgent
+                    provider:
+                      type: io.kestra.plugin.ai.provider.OpenAI
+                      apiKey: "{{ secret('OPENAI_API_KEY') }}"
+                      modelName: gpt-5-mini
+                    memory:
+                      type: io.kestra.plugin.ai.memory.KestraKVStore
+                      memoryId: JOHN
+                      ttl: PT1M
+                      messages: 5
                     prompt: Hi, my name is John and I live in New York!
 
                   - id: second_agent
                     type: io.kestra.plugin.ai.agent.AIAgent
+                    provider:
+                      type: io.kestra.plugin.ai.provider.OpenAI
+                      apiKey: "{{ secret('OPENAI_API_KEY') }}"
+                      modelName: gpt-5-mini
+                    memory:
+                      type: io.kestra.plugin.ai.memory.KestraKVStore
+                      memoryId: JOHN
+                      ttl: PT1M
+                      messages: 5
                     prompt: What's my name and where do I live?
-
-                pluginDefaults:
-                  - type: io.kestra.plugin.ai.agent.AIAgent
-                    values:
-                      provider:
-                        type: io.kestra.plugin.ai.provider.OpenAI
-                        apiKey: "{{ secret('OPENAI_API_KEY') }}"
-                        modelName: gpt-5-mini
-                      memory:
-                        type: io.kestra.plugin.ai.memory.KestraKVStore
-                        memoryId: JOHN
-                        ttl: PT1M
-                        messages: 5
                 """
         ),
         @Example(

--- a/src/main/java/io/kestra/plugin/ai/rag/ChatCompletion.java
+++ b/src/main/java/io/kestra/plugin/ai/rag/ChatCompletion.java
@@ -85,6 +85,8 @@ import static io.kestra.core.utils.Rethrow.throwFunction;
                         type: io.kestra.plugin.ai.completion.ChatCompletion
                         provider:
                           type: io.kestra.plugin.ai.provider.GoogleGemini
+                          modelName: gemini-3.5-flash-lite
+                          apiKey: "{{ secret('GEMINI_API_KEY') }}"
                         messages:
                           - type: USER
                             content: Which features were released in Kestra 0.24?
@@ -93,19 +95,16 @@ import static io.kestra.core.utils.Rethrow.throwFunction;
                         type: io.kestra.plugin.ai.rag.ChatCompletion
                         chatProvider:
                           type: io.kestra.plugin.ai.provider.GoogleGemini
+                          modelName: gemini-3.5-flash-lite
+                          apiKey: "{{ secret('GEMINI_API_KEY') }}"
                         embeddingProvider:
                           type: io.kestra.plugin.ai.provider.GoogleGemini
                           modelName: gemini-embedding-001
+                          apiKey: "{{ secret('GEMINI_API_KEY') }}"
                         embeddings:
                           type: io.kestra.plugin.ai.embeddings.KestraKVStore
                         systemMessage: You are a helpful assistant that can answer questions about Kestra.
-                        prompt: Which features were released in Kestra 0.24?
-
-                pluginDefaults:
-                  - type: io.kestra.plugin.ai.provider.GoogleGemini
-                    values:
-                      apiKey: "{{ secret('GEMINI_API_KEY') }}"
-                      modelName: gemini-3.5-flash-lite"""
+                        prompt: Which features were released in Kestra 0.24?"""
         ),
         @Example(
             full = true,
@@ -148,9 +147,12 @@ import static io.kestra.core.utils.Rethrow.throwFunction;
                     type: io.kestra.plugin.ai.rag.ChatCompletion
                     chatProvider:
                       type: io.kestra.plugin.ai.provider.GoogleGemini
+                      modelName: gemini-3.5-flash-lite
+                      apiKey: "{{ secret('GEMINI_API_KEY') }}"
                     embeddingProvider:
                       type: io.kestra.plugin.ai.provider.GoogleGemini
                       modelName: gemini-embedding-001
+                      apiKey: "{{ secret('GEMINI_API_KEY') }}"
                     embeddings:
                       type: io.kestra.plugin.ai.embeddings.KestraKVStore
                     memory:
@@ -163,21 +165,18 @@ import static io.kestra.core.utils.Rethrow.throwFunction;
                     type: io.kestra.plugin.ai.rag.ChatCompletion
                     chatProvider:
                       type: io.kestra.plugin.ai.provider.GoogleGemini
+                      modelName: gemini-3.5-flash-lite
+                      apiKey: "{{ secret('GEMINI_API_KEY') }}"
                     embeddingProvider:
                       type: io.kestra.plugin.ai.provider.GoogleGemini
                       modelName: gemini-embedding-001
+                      apiKey: "{{ secret('GEMINI_API_KEY') }}"
                     embeddings:
                       type: io.kestra.plugin.ai.embeddings.KestraKVStore
                     memory:
                       type: io.kestra.plugin.ai.memory.KestraKVStore
                     systemMessage: You are a helpful assistant, answer concisely
-                    prompt: "{{ inputs.second }}"
-
-                pluginDefaults:
-                  - type: io.kestra.plugin.ai.provider.GoogleGemini
-                    values:
-                      apiKey: "{{ secret('GEMINI_API_KEY') }}"
-                      modelName: gemini-3.5-flash-lite"""
+                    prompt: "{{ inputs.second }}\""""
         ),
         @Example(
             full = true,

--- a/src/main/java/io/kestra/plugin/ai/tool/KestraFlow.java
+++ b/src/main/java/io/kestra/plugin/ai/tool/KestraFlow.java
@@ -3,6 +3,7 @@ package io.kestra.plugin.ai.tool;
 import java.time.OffsetDateTime;
 import java.time.ZonedDateTime;
 import java.util.*;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
@@ -17,6 +18,7 @@ import io.kestra.core.models.property.Property;
 import io.kestra.core.runners.RunContext;
 import io.kestra.core.runners.SDK;
 import io.kestra.core.serializers.JacksonMapper;
+import io.kestra.core.tenant.TenantService;
 import io.kestra.core.serializers.ListOrMapOfLabelDeserializer;
 import io.kestra.core.serializers.ListOrMapOfLabelSerializer;
 import io.kestra.core.utils.IdUtils;
@@ -36,6 +38,7 @@ import com.fasterxml.jackson.core.type.TypeReference;
 
 import dev.langchain4j.agent.tool.ToolExecutionRequest;
 import dev.langchain4j.agent.tool.ToolSpecification;
+import dev.langchain4j.exception.LangChain4jException;
 import dev.langchain4j.exception.ToolArgumentsException;
 import dev.langchain4j.exception.ToolExecutionException;
 import dev.langchain4j.model.chat.request.json.JsonArraySchema;
@@ -63,6 +66,12 @@ import static io.kestra.core.utils.Rethrow.throwFunction;
                 """
                     id: agent_calling_flows_explicitly
                     namespace: company.ai
+
+                    pluginDefaults:
+                      - type: io.kestra.plugin.ai.tool.KestraFlow
+                        values:
+                          auth:
+                            apiToken: "{{ secret('KESTRA_API_TOKEN') }}"
 
                     inputs:
                       - id: use_case
@@ -168,7 +177,9 @@ import static io.kestra.core.utils.Rethrow.throwFunction;
                           modelName: gemini-3.5-flash-lite
                           apiKey: "{{ secret('GEMINI_API_KEY') }}"
                         tools:
-                          - type: io.kestra.plugin.ai.tool.KestraFlow"""
+                          - type: io.kestra.plugin.ai.tool.KestraFlow
+                            auth:
+                              apiToken: "{{ secret('KESTRA_API_TOKEN') }}\""""
             }
         ),
     }
@@ -185,6 +196,9 @@ public class KestraFlow extends ToolProvider {
     private static final String TOOL_LLM_DESCRIPTION = """
         This tool executes a Kestra workflow, also called a flow. This tool will respond with the flow execution information.
         The namespace and the ID of the flow must be passed as tool parameters.""";
+
+    private static final String DEFAULT_URL = "http://localhost:8080";
+    private static final String URL_TEMPLATE = "{{ kestra.url }}";
 
     @Schema(
         title = "Description of the flow if not already provided inside the flow itself",
@@ -276,18 +290,33 @@ public class KestraFlow extends ToolProvider {
         return Optional.empty();
     }
 
+    private String resolveUrl(RunContext runContext) throws IllegalVariableEvaluationException {
+        String rUrl = runContext.render(kestraUrl).as(String.class)
+            .filter(Predicate.not(String::isBlank))
+            .orElseGet(() -> configuredUrl(runContext));
+
+        return rUrl.trim().replaceAll("/+$", "");
+    }
+
+    private static String configuredUrl(RunContext runContext) {
+        try {
+            String rUrl = runContext.render(URL_TEMPLATE);
+            return rUrl == null || rUrl.isBlank() ? DEFAULT_URL : rUrl;
+        } catch (IllegalVariableEvaluationException e) {
+            return DEFAULT_URL;
+        }
+    }
+
+    private static IllegalArgumentException noAuthentication() {
+        return new IllegalArgumentException(
+            "No authentication method provided. Set the `auth` property of the tool, or configure a default one with the `kestra.tasks.sdk.authentication` properties."
+        );
+    }
+
     private KestraClient kestraClient(RunContext runContext) throws IllegalVariableEvaluationException {
-        String rKestraUrl = runContext.render(kestraUrl).as(String.class)
-            .orElseGet(() -> {
-                try {
-                    return runContext.render("{{ kestra.url }}");
-                } catch (IllegalVariableEvaluationException e) {
-                    return "http://localhost:8080";
-                }
-            });
-        String normalizedUrl = rKestraUrl.trim().replaceAll("/+$", "");
         var builder = KestraClient.builder();
-        builder.url(normalizedUrl);
+        builder.url(resolveUrl(runContext));
+
         if (auth != null) {
             String rApiToken = runContext.render(auth.apiToken).as(String.class).orElse(null);
             if (rApiToken != null) {
@@ -299,13 +328,23 @@ public class KestraFlow extends ToolProvider {
                 return builder.basicAuth(maybeUsername.get(), maybePassword.get()).build();
             }
             if (runContext.render(auth.auto).as(Boolean.class).orElse(Boolean.TRUE)) {
-                return tryAutoAuth(builder, runContext)
-                    .orElseThrow(() -> new IllegalArgumentException("No authentication method provided"));
+                return tryAutoAuth(builder, runContext).orElseThrow(KestraFlow::noAuthentication);
             }
-            throw new IllegalArgumentException("No authentication method provided");
-        } else {
-            return tryAutoAuth(builder, runContext).orElse(builder.build());
+            throw noAuthentication();
         }
+
+        return tryAutoAuth(builder, runContext).orElseThrow(KestraFlow::noAuthentication);
+    }
+
+    /** A 401 or a 403 from the API is a credentials problem, and reporting it as a missing flow sends the user looking in the wrong place. */
+    private static String apiFailureMessage(ApiException e, String namespace, String flowId) {
+        return switch (e.getCode()) {
+            case 401 -> "Authentication failed when calling the Kestra API for the flow '%s' in the namespace '%s'. Check the credentials set in the `auth` property of the tool.".formatted(flowId, namespace);
+            case 403 -> "Not authorized to access the flow '%s' in the namespace '%s'. Check the permissions of the credentials set in the `auth` property of the tool.".formatted(flowId, namespace);
+            case 404 -> "Unable to find the flow '%s' in the namespace '%s'.".formatted(flowId, namespace);
+            case 0 -> "The Kestra API could not be reached for the flow '%s' in the namespace '%s': %s".formatted(flowId, namespace, e.getMessage());
+            default -> "The Kestra API returned the status %d for the flow '%s' in the namespace '%s': %s".formatted(e.getCode(), flowId, namespace, e.getMessage());
+        };
     }
 
     @Override
@@ -329,7 +368,9 @@ public class KestraFlow extends ToolProvider {
 
         // resolve tenant id: explicit property overrides, otherwise fall back to current execution's tenant
         String rTenantId = runContext.render(this.tenantId).as(String.class, additionalVariables)
-            .orElse(Objects.toString(runContext.flowInfo().tenantId(), ""));
+            .filter(Predicate.not(String::isBlank))
+            .or(() -> Optional.ofNullable(runContext.flowInfo().tenantId()))
+            .orElse(TenantService.MAIN_TENANT);
 
         var client = kestraClient(runContext);
 
@@ -369,7 +410,7 @@ public class KestraFlow extends ToolProvider {
             try {
                 flowWithSource = client.flows().flow(rNamespace, rFlowId, rTenantId, false, rRevision.orElse(null), false);
             } catch (ApiException e) {
-                throw new IllegalArgumentException("Unable to find flow '" + rFlowId + "' in namespace '" + rNamespace + "'", e);
+                throw new IllegalArgumentException(apiFailureMessage(e, rNamespace, rFlowId), e);
             }
 
             var rDescription = runContext.render(this.description).as(String.class, additionalVariables).orElse(flowWithSource.getDescription());
@@ -452,13 +493,15 @@ public class KestraFlow extends ToolProvider {
             try {
                 return client.flows().flow(namespace, flowId, tenantId, false, revision, false);
             } catch (ApiException e) {
-                throw new ToolExecutionException("Flow not found: " + namespace + "." + flowId, e);
+                // langchain4j reports the root cause's message to the agent, so chaining the ApiException would hide this one
+                runContext.logger().warn("Calling the Kestra API failed with the status {}.", e.getCode(), e);
+                throw new ToolExecutionException(apiFailureMessage(e, namespace, flowId));
             }
         }
     }
 
     static abstract class AbstractKestraFlowToolExecutor implements ToolExecutor {
-        private final RunContext runContext;
+        protected final RunContext runContext;
         protected final KestraClient client;
         protected final String tenantId;
         private final Map<String, Object> predefinedInputs;
@@ -522,20 +565,29 @@ public class KestraFlow extends ToolProvider {
                 });
 
                 var executionsApi = new ExecutionsApiWithInputs(client.executions().getApiClient());
-                var response = executionsApi.createExecutionWithInputs(
-                    tenantId,
-                    flowWithSource.getNamespace(),
-                    flowWithSource.getId(),
-                    sdkLabels,
-                    false,
-                    flowWithSource.getRevision(),
-                    scheduledDate.map(ZonedDateTime::toOffsetDateTime).orElse(null),
-                    null,
-                    null,
-                    new HashMap<>(finalInputs)
-                );
+                ExecutionControllerExecutionResponse response;
+                try {
+                    response = executionsApi.createExecutionWithInputs(
+                        tenantId,
+                        flowWithSource.getNamespace(),
+                        flowWithSource.getId(),
+                        sdkLabels,
+                        false,
+                        flowWithSource.getRevision(),
+                        scheduledDate.map(ZonedDateTime::toOffsetDateTime).orElse(null),
+                        null,
+                        null,
+                        new HashMap<>(finalInputs)
+                    );
+                } catch (ApiException e) {
+                    // langchain4j reports the root cause's message to the agent, so chaining the ApiException would hide this one
+                    runContext.logger().warn("Calling the Kestra API failed with the status {}.", e.getCode(), e);
+                    throw new ToolExecutionException(apiFailureMessage(e, flowWithSource.getNamespace(), flowWithSource.getId()));
+                }
 
                 return JacksonMapper.ofJson().writeValueAsString(response);
+            } catch (LangChain4jException e) {
+                throw e;
             } catch (Exception e) {
                 throw new ToolExecutionException(e);
             }

--- a/src/main/java/io/kestra/plugin/ai/tool/KestraFlow.java
+++ b/src/main/java/io/kestra/plugin/ai/tool/KestraFlow.java
@@ -67,12 +67,6 @@ import static io.kestra.core.utils.Rethrow.throwFunction;
                     id: agent_calling_flows_explicitly
                     namespace: company.ai
 
-                    pluginDefaults:
-                      - type: io.kestra.plugin.ai.tool.KestraFlow
-                        values:
-                          auth:
-                            apiToken: "{{ secret('KESTRA_API_TOKEN') }}"
-
                     inputs:
                       - id: use_case
                         type: SELECT
@@ -100,41 +94,57 @@ import static io.kestra.core.utils.Rethrow.throwFunction;
                             namespace: tutorial
                             flowId: business-automation
                             description: Business Automation
+                            auth:
+                              apiToken: "{{ secret('KESTRA_API_TOKEN') }}"
 
                           - type: io.kestra.plugin.ai.tool.KestraFlow
                             namespace: tutorial
                             flowId: business-processes
                             description: Business Processes
+                            auth:
+                              apiToken: "{{ secret('KESTRA_API_TOKEN') }}"
 
                           - type: io.kestra.plugin.ai.tool.KestraFlow
                             namespace: tutorial
                             flowId: data-engineering-pipeline
                             description: Data Engineering Pipeline
+                            auth:
+                              apiToken: "{{ secret('KESTRA_API_TOKEN') }}"
 
                           - type: io.kestra.plugin.ai.tool.KestraFlow
                             namespace: tutorial
                             flowId: dwh-and-analytics
                             description: Data Warehouse and Analytics
+                            auth:
+                              apiToken: "{{ secret('KESTRA_API_TOKEN') }}"
 
                           - type: io.kestra.plugin.ai.tool.KestraFlow
                             namespace: tutorial
                             flowId: file-processing
                             description: File Processing
+                            auth:
+                              apiToken: "{{ secret('KESTRA_API_TOKEN') }}"
 
                           - type: io.kestra.plugin.ai.tool.KestraFlow
                             namespace: tutorial
                             flowId: hello-world
                             description: Hello World
+                            auth:
+                              apiToken: "{{ secret('KESTRA_API_TOKEN') }}"
 
                           - type: io.kestra.plugin.ai.tool.KestraFlow
                             namespace: tutorial
                             flowId: infrastructure-automation
                             description: Infrastructure Automation
+                            auth:
+                              apiToken: "{{ secret('KESTRA_API_TOKEN') }}"
 
                           - type: io.kestra.plugin.ai.tool.KestraFlow
                             namespace: tutorial
                             flowId: microservices-and-apis
-                            description: Microservices and APIs"""
+                            description: Microservices and APIs
+                            auth:
+                              apiToken: "{{ secret('KESTRA_API_TOKEN') }}\""""
             }
         ),
         @Example(

--- a/src/test/java/io/kestra/plugin/ai/tool/KestraFlowTest.java
+++ b/src/test/java/io/kestra/plugin/ai/tool/KestraFlowTest.java
@@ -7,6 +7,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -16,6 +17,10 @@ import org.junit.jupiter.api.parallel.ExecutionMode;
 import org.junit.jupiter.api.parallel.ResourceLock;
 
 import com.sun.net.httpserver.HttpServer;
+import dev.langchain4j.agent.tool.ToolExecutionRequest;
+import dev.langchain4j.exception.ToolArgumentsException;
+import dev.langchain4j.exception.ToolExecutionException;
+import dev.langchain4j.service.tool.ToolExecutor;
 import dev.langchain4j.model.chat.request.ResponseFormatType;
 import dev.langchain4j.model.output.FinishReason;
 import io.kestra.core.junit.annotations.KestraTest;
@@ -30,6 +35,7 @@ import io.kestra.plugin.ai.provider.OpenAI;
 import jakarta.inject.Inject;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @Execution(ExecutionMode.SAME_THREAD)
 @ResourceLock("kestra-h2-flyway")
@@ -42,13 +48,17 @@ class KestraFlowTest {
     private int mockPort;
     private final Map<String, String> stubFlowResponses = new ConcurrentHashMap<>();
     private final Map<String, String> stubExecResponses = new ConcurrentHashMap<>();
+    private final Map<String, Integer> stubStatuses = new ConcurrentHashMap<>();
     private final AtomicBoolean executionCreated = new AtomicBoolean(false);
+    private final AtomicInteger requestCount = new AtomicInteger();
 
     @BeforeEach
     void setUp() throws IOException {
         stubFlowResponses.clear();
         stubExecResponses.clear();
+        stubStatuses.clear();
         executionCreated.set(false);
+        requestCount.set(0);
         mockServer = HttpServer.create(new InetSocketAddress(0), 0);
         mockServer.createContext("/", exchange -> {
             String path = exchange.getRequestURI().getPath();
@@ -56,9 +66,15 @@ class KestraFlowTest {
             // Drain request body without parsing it as multipart — avoids
             // Apache Commons FileUpload "no multipart boundary" errors
             exchange.getRequestBody().readAllBytes();
+            requestCount.incrementAndGet();
             byte[] responseBytes;
             int status;
-            if ("GET".equalsIgnoreCase(method)) {
+            Integer forcedStatus = stubStatuses.get(path);
+            if (forcedStatus != null) {
+                String errorBody = stubFlowResponses.get(path);
+                responseBytes = (errorBody != null ? errorBody : "{}").getBytes(StandardCharsets.UTF_8);
+                status = forcedStatus;
+            } else if ("GET".equalsIgnoreCase(method)) {
                 String body = stubFlowResponses.get(path);
                 if (body != null) {
                     responseBytes = body.getBytes(StandardCharsets.UTF_8);
@@ -117,10 +133,9 @@ class KestraFlowTest {
 
     @Test
     void helloWorld() throws Exception {
-        // The SDK uses an empty tenant string, producing a double-slash path: /api/v1//flows/...
-        stubFlowResponses.put("/api/v1//flows/company.team/hello-world",
+        stubFlowResponses.put("/api/v1/main/flows/company.team/hello-world",
             flowJson("company.team", "hello-world", 1, null, null));
-        stubExecResponses.put("/api/v1//executions/company.team/hello-world",
+        stubExecResponses.put("/api/v1/main/executions/company.team/hello-world",
             executionJson("test-exec-123", "company.team", "hello-world"));
 
         RunContext runContext = runContextFactory.of(
@@ -147,6 +162,7 @@ class KestraFlowTest {
                         .flowId(Property.ofValue("hello-world"))
                         .description(Property.ofValue("A flow that say Hello World"))
                         .kestraUrl(Property.ofValue("http://localhost:" + mockPort))
+                        .auth(apiTokenAuth())
                         .build()
                 )
             )
@@ -176,9 +192,9 @@ class KestraFlowTest {
 
     @Test
     void descriptionFromTheFlow() throws Exception {
-        stubFlowResponses.put("/api/v1//flows/company.team/hello-world-with-description",
+        stubFlowResponses.put("/api/v1/main/flows/company.team/hello-world-with-description",
             flowJson("company.team", "hello-world-with-description", 1, "A flow that say Hello World", null));
-        stubExecResponses.put("/api/v1//executions/company.team/hello-world-with-description",
+        stubExecResponses.put("/api/v1/main/executions/company.team/hello-world-with-description",
             executionJson("test-exec-456", "company.team", "hello-world-with-description"));
 
         RunContext runContext = runContextFactory.of(
@@ -204,6 +220,7 @@ class KestraFlowTest {
                         .namespace(Property.ofValue("company.team"))
                         .flowId(Property.ofValue("hello-world-with-description"))
                         .kestraUrl(Property.ofValue("http://localhost:" + mockPort))
+                        .auth(apiTokenAuth())
                         .build()
                 )
             )
@@ -242,9 +259,9 @@ class KestraFlowTest {
     @Test
     void inputsAndLabels() throws Exception {
         String inputsJson = "[{\"id\":\"name\",\"type\":\"STRING\",\"required\":false}]";
-        stubFlowResponses.put("/api/v1//flows/company.team/hello-world-with-input",
+        stubFlowResponses.put("/api/v1/main/flows/company.team/hello-world-with-input",
             flowJson("company.team", "hello-world-with-input", 1, null, inputsJson));
-        stubExecResponses.put("/api/v1//executions/company.team/hello-world-with-input",
+        stubExecResponses.put("/api/v1/main/executions/company.team/hello-world-with-input",
             executionJson("test-exec-789", "company.team", "hello-world-with-input"));
 
         RunContext runContext = runContextFactory.of(
@@ -271,6 +288,7 @@ class KestraFlowTest {
                         .flowId(Property.ofValue("hello-world-with-input"))
                         .description(Property.ofValue("A flow that say Hello World"))
                         .kestraUrl(Property.ofValue("http://localhost:" + mockPort))
+                        .auth(apiTokenAuth())
                         .build()
                 )
             )
@@ -301,9 +319,9 @@ class KestraFlowTest {
 
     @Test
     void helloWorldFromLLM() throws Exception {
-        stubFlowResponses.put("/api/v1//flows/company.team/hello-world",
+        stubFlowResponses.put("/api/v1/main/flows/company.team/hello-world",
             flowJson("company.team", "hello-world", 1, "A flow that says Hello World", null));
-        stubExecResponses.put("/api/v1//executions/company.team/hello-world",
+        stubExecResponses.put("/api/v1/main/executions/company.team/hello-world",
             executionJson("test-exec-llm", "company.team", "hello-world"));
 
         RunContext runContext = runContextFactory.of(
@@ -327,6 +345,7 @@ class KestraFlowTest {
                 List.of(
                     KestraFlow.builder()
                         .kestraUrl(Property.ofValue("http://localhost:" + mockPort))
+                        .auth(apiTokenAuth())
                         .build()
                 )
             )
@@ -353,5 +372,150 @@ class KestraFlowTest {
         assertThat(output.getIntermediateResponses().getFirst().getRequestDuration()).isNotNull();
         assertThat(executionCreated).isTrue();
         assertThat(output.getTextOutput()).contains("test-exec-llm");
+    }
+    private KestraFlow.Auth apiTokenAuth() {
+        return KestraFlow.Auth.builder().apiToken(Property.ofValue("test-token")).build();
+    }
+
+    private KestraFlow definedFlowTool(String flowId, KestraFlow.Auth auth) {
+        return KestraFlow.builder()
+            .namespace(Property.ofValue("company.team"))
+            .flowId(Property.ofValue(flowId))
+            .description(Property.ofValue("A flow that say Hello World"))
+            .kestraUrl(Property.ofValue("http://localhost:" + mockPort))
+            .auth(auth)
+            .build();
+    }
+
+    private ToolExecutor executorOf(KestraFlow tool) throws Exception {
+        return tool.tool(runContextFactory.of(), Map.of()).values().iterator().next();
+    }
+
+    @Test
+    void shouldReportAnAuthenticationFailureWhenTheApiRejectsTheCredentials() {
+        stubStatuses.put("/api/v1/main/flows/company.team/hello-world", 401);
+
+        var tool = definedFlowTool("hello-world", apiTokenAuth());
+
+        assertThatThrownBy(() -> tool.tool(runContextFactory.of(), Map.of()))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("Authentication failed")
+            .hasMessageContaining("hello-world");
+    }
+
+    @Test
+    void shouldReportAnAuthorizationFailureWhenTheApiForbidsTheFlow() {
+        stubStatuses.put("/api/v1/main/flows/company.team/hello-world", 403);
+
+        var tool = definedFlowTool("hello-world", apiTokenAuth());
+
+        assertThatThrownBy(() -> tool.tool(runContextFactory.of(), Map.of()))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("Not authorized");
+    }
+
+    @Test
+    void shouldStillReportAMissingFlowWhenTheApiReturnsNotFound() {
+        var tool = definedFlowTool("unknown-flow", apiTokenAuth());
+
+        assertThatThrownBy(() -> tool.tool(runContextFactory.of(), Map.of()))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("Unable to find the flow 'unknown-flow'");
+    }
+
+    @Test
+    void shouldReportAnAuthenticationFailureWhenTheFlowIsResolvedByTheLlm() throws Exception {
+        stubStatuses.put("/api/v1/main/flows/company.team/hello-world", 401);
+
+        var tool = KestraFlow.builder().kestraUrl(Property.ofValue("http://localhost:" + mockPort)).auth(apiTokenAuth()).build();
+        var executor = executorOf(tool);
+        var request = ToolExecutionRequest.builder()
+            .id("1")
+            .name("kestra_flow")
+            .arguments("{\"namespace\":\"company.team\",\"flowId\":\"hello-world\"}")
+            .build();
+
+        assertThatThrownBy(() -> executor.execute(request, "memory"))
+            .isInstanceOf(ToolExecutionException.class)
+            .hasMessageStartingWith("Authentication failed")
+            .cause().hasMessageStartingWith("Authentication failed");
+    }
+
+    @Test
+    void shouldReportAnAuthenticationFailureWhenTheExecutionIsRejected() throws Exception {
+        stubFlowResponses.put("/api/v1/main/flows/company.team/hello-world",
+            flowJson("company.team", "hello-world", 1, null, null));
+        stubStatuses.put("/api/v1/main/executions/company.team/hello-world", 401);
+
+        var tool = definedFlowTool("hello-world", apiTokenAuth());
+        var executor = executorOf(tool);
+        var request = ToolExecutionRequest.builder().id("1").name("kestra_flow").arguments("{}").build();
+
+        assertThatThrownBy(() -> executor.execute(request, "memory"))
+            .isInstanceOf(ToolExecutionException.class)
+            .hasMessageStartingWith("Authentication failed")
+            .cause().hasMessageStartingWith("Authentication failed");
+    }
+
+    @Test
+    void shouldFailBeforeCallingTheApiWhenNoCredentialsCanBeRetrieved() {
+        var tool = definedFlowTool("hello-world", null);
+
+        assertThatThrownBy(() -> tool.tool(runContextFactory.of(), Map.of()))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("No authentication method provided");
+        assertThat(requestCount).hasValue(0);
+    }
+    @Test
+    void shouldReportAMissingInputAsAnArgumentsProblem() throws Exception {
+        stubFlowResponses.put("/api/v1/main/flows/company.team/hello-world",
+            flowJson("company.team", "hello-world", 1, null, "[{\"id\":\"name\",\"type\":\"STRING\",\"required\":true}]"));
+
+        var tool = definedFlowTool("hello-world", apiTokenAuth());
+        var executor = executorOf(tool);
+        var request = ToolExecutionRequest.builder().id("1").name("kestra_flow").arguments("{}").build();
+
+        assertThatThrownBy(() -> executor.execute(request, "memory"))
+            .isInstanceOf(ToolArgumentsException.class)
+            .hasMessageContaining("'name'");
+    }
+    /** The SDK builder defaults to Basic auth, so building a client without credentials would send `Basic base64("null:null")`. */
+    @Test
+    void shouldFailWhenAutoIsDisabledWithoutCredentials() {
+        var tool = definedFlowTool("hello-world", KestraFlow.Auth.builder().auto(Property.ofValue(false)).build());
+
+        assertThatThrownBy(() -> tool.tool(runContextFactory.of(), Map.of()))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("No authentication method provided");
+        assertThat(requestCount).hasValue(0);
+    }
+
+    @Test
+    void shouldIncludeTheApiMessageWhenTheStatusIsNotMapped() {
+        stubStatuses.put("/api/v1/main/flows/company.team/hello-world", 500);
+        stubFlowResponses.put("/api/v1/main/flows/company.team/hello-world",
+            "{\"message\":\"the database is unreachable\"}");
+
+        var tool = definedFlowTool("hello-world", apiTokenAuth());
+
+        assertThatThrownBy(() -> tool.tool(runContextFactory.of(), Map.of()))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("returned the status 500")
+            .hasMessageContaining("the database is unreachable");
+    }
+
+    @Test
+    void shouldReportAnUnreachableApiInsteadOfAMissingFlow() {
+        var tool = KestraFlow.builder()
+            .namespace(Property.ofValue("company.team"))
+            .flowId(Property.ofValue("hello-world"))
+            .description(Property.ofValue("A flow that say Hello World"))
+            .kestraUrl(Property.ofValue("http://localhost:1"))
+            .auth(apiTokenAuth())
+            .build();
+
+        assertThatThrownBy(() -> tool.tool(runContextFactory.of(), Map.of()))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("could not be reached");
     }
 }


### PR DESCRIPTION
Closes https://github.com/kestra-io/plugin-ai/issues/404.

### What changes are being made and why?

- A 401 or a 403 from the Kestra API was reported as `Flow not found`, so a wrong or unauthorized credential sent the user looking for a flow that was there all along. Each status is now named for what it is, and only a genuine 404 is reported as a missing flow. The mapping covers the three places the API is called: resolving a flow defined on the tool, resolving one the LLM asked for, and creating the execution.
- Without an `auth` block the tool fell back to an unauthenticated request when automatic credential retrieval found nothing, producing that same misleading 401. It now fails at that point, the way it already did when an `auth` block was set. `auto: false` with no credentials keeps throwing, unchanged.
- A `ToolArgumentsException` raised for a missing input was being wrapped into a generic `ToolExecutionException`; it is now rethrown as-is, so the right handler and observability listener fire. (The agent's `toolArgumentsErrorHandler` still rethrows rather than returning the error to the LLM, so this does not by itself enable a retry — see the review discussion.)
- `kestraUrl` is untouched — same name, same place, same meaning. Its resolution moves into a helper that rejects a blank `{{ kestra.url }}` rather than building a client with an empty base path. **Not a breaking change.**

Review follow-up:
- The auth messages now actually reach the agent: langchain4j reports the root cause of what an executor throws, so the two executor sites no longer chain the `ApiException` (it is logged at warn instead), and the tests pin the surfaced message.
- `auth.auto: false` with no credentials still throws, and cannot be turned into an anonymous call from here: the SDK's `KestraClientBuilder` starts on `Auth.BASIC` and exposes no setter for `Auth.NONE`, so `build()` without credentials would send `Authorization: Basic base64("null:null")` rather than no header. Calling an unsecured API needs a `noAuth()` on that builder in `client-sdk` first.
- Both doc examples gained the `auth` block they need on an instance without a default authentication, and `pluginDefaults` is gone from every example in this plugin since it no longer exists after Kestra 2.0.
- An `ApiException` with status 0 (no HTTP response at all) is reported as an unreachable API with the underlying message, not as `status 0`, and any unmapped status now carries the API's own message, which this SDK exposes as the response body.
- An unset tenant was serialized as `""`, producing `/api/v1//flows/...` paths; it now falls back to the flow's tenant and then to `main`.

### How the changes have been QAed?

```yaml
id: agent_calling_a_flow
namespace: company.ai

tasks:
  - id: agent
    type: io.kestra.plugin.ai.agent.AIAgent
    provider:
      type: io.kestra.plugin.ai.provider.GoogleGemini
      apiKey: "{{ kv('GEMINI_API_KEY') }}"
      modelName: gemini-2.5-flash
    prompt: Run the hello-world flow and give me its execution id.
    tools:
      - type: io.kestra.plugin.ai.tool.KestraFlow
        namespace: company.team
        flowId: hello-world
        kestraUrl: http://localhost:8080
        auth:
          apiToken: "{{ kv('KESTRA_API_TOKEN') }}"
```

With a wrong `apiToken` the agent now reports `Authentication failed when calling the Kestra API for the flow 'hello-world' in the namespace 'company.team'. Check the credentials set in the auth property of the tool.` instead of `Flow not found: company.team.hello-world`. Dropping the whole `auth` block on an instance with no `kestra.tasks.sdk.authentication` configured fails before any request, with `No authentication method provided`.

Fourteen tests in `KestraFlowTest` cover the three failure sites, the fail-fast on missing credentials, the arguments exception, an unreachable API and an unmapped status.


