### PR TITLE
build: migrate to Kestra 2.0 and Java 25, and allow unauthenticated Kestra API calls

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -46,4 +46,5 @@ jobs:
     with:
       skip-test: ${{ github.event.inputs.skip-test == 'true' }}
       kestra-version: ${{ github.event.inputs.kestra-version }}
+      java-version: '25'
     secrets: inherit

--- a/build.gradle
+++ b/build.gradle
@@ -27,7 +27,7 @@ repositories {
     }
 }
 
-final targetJavaVersion = JavaVersion.VERSION_21
+final targetJavaVersion = JavaVersion.VERSION_25
 
 java {
     sourceCompatibility = targetJavaVersion
@@ -55,7 +55,7 @@ dependencies {
     annotationProcessor group: "io.kestra", name: "processor", version: kestraVersion
     compileOnly group: "io.kestra", name: "core", version: kestraVersion
     compileOnly group: "io.kestra", name: "script", version: kestraVersion
-    implementation "io.kestra:kestra-api-client:1.3.2"
+    implementation "io.kestra:kestra-api-client:2.0.0"
 
     // compileOnly as it comes from Kestra script library
     compileOnly('com.github.docker-java:docker-java') {
@@ -175,7 +175,7 @@ dependencies {
     testImplementation "org.wiremock:wiremock-jetty12"
 
     // used in KestraTaskTest to exercise a real RunnableTask (log fetching) as an AI tool
-    testImplementation group: "io.kestra.plugin", name: "plugin-kestra", version: "1.11.4"
+    testImplementation group: "io.kestra.plugin", name: "plugin-kestra", version: "2.0.3"
 
     testImplementation 'org.testcontainers:ollama:1.21.4'
     testImplementation 'org.testcontainers:elasticsearch:1.21.4'

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
 version=1.16.1-SNAPSHOT
-kestraVersion=1.3.17
+kestraVersion=2.0.0
 org.gradle.jvmargs=-Xmx1g -XX:MaxMetaspaceSize=1g -XX:+ExitOnOutOfMemoryError -XX:+HeapDumpOnOutOfMemoryError

--- a/src/main/java/io/kestra/plugin/ai/tool/KestraFlow.java
+++ b/src/main/java/io/kestra/plugin/ai/tool/KestraFlow.java
@@ -319,7 +319,7 @@ public class KestraFlow extends ToolProvider {
 
     private static IllegalArgumentException noAuthentication() {
         return new IllegalArgumentException(
-            "No authentication method provided. Set the `auth` property of the tool, or configure a default one with the `kestra.tasks.sdk.authentication` properties."
+            "No authentication method provided. Set the `auth` property of the tool, or configure a default one with the `kestra.tasks.sdk.authentication` properties. Set `auth.auto` to false to call a Kestra API that requires no authentication."
         );
     }
 
@@ -340,7 +340,8 @@ public class KestraFlow extends ToolProvider {
             if (runContext.render(auth.auto).as(Boolean.class).orElse(Boolean.TRUE)) {
                 return tryAutoAuth(builder, runContext).orElseThrow(KestraFlow::noAuthentication);
             }
-            throw noAuthentication();
+
+            return builder.noAuth().build();
         }
 
         return tryAutoAuth(builder, runContext).orElseThrow(KestraFlow::noAuthentication);
@@ -663,7 +664,10 @@ public class KestraFlow extends ToolProvider {
         @PluginProperty(secret = true, group = "connection")
         private Property<String> password;
 
-        @Schema(title = "Automatically retrieve credentials from Kestra's configuration if available")
+        @Schema(
+            title = "Automatically retrieve credentials from Kestra's configuration if available",
+            description = "Set this to `false` without any credentials to call a Kestra API that requires no authentication."
+        )
         @Builder.Default
         @PluginProperty(group = "advanced")
         private Property<Boolean> auto = Property.ofValue(Boolean.TRUE);

--- a/src/test/java/io/kestra/plugin/ai/RemoteA2AAgentController.java
+++ b/src/test/java/io/kestra/plugin/ai/RemoteA2AAgentController.java
@@ -16,19 +16,19 @@ public class RemoteA2AAgentController {
                     "jsonrpc": "2.0",
                     "id": "req_id",
                     "result": {
-                        "kind": "task",
-                        "id": "001",
-                        "contextId": "002",
-                        "status": {
-                            "state": "completed"
-                        },
-                        "artifacts": [{
-                            "artifactId": "001",
-                            "parts": [{
-                                "kind": "text",
-                                "text": "Hello World"
+                        "task": {
+                            "id": "001",
+                            "contextId": "002",
+                            "status": {
+                                "state": "TASK_STATE_COMPLETED"
+                            },
+                            "artifacts": [{
+                                "artifactId": "001",
+                                "parts": [{
+                                    "text": "Hello World"
+                                }]
                             }]
-                        }]
+                        }
                     }
                 }
             """;
@@ -41,6 +41,10 @@ public class RemoteA2AAgentController {
                     "name": "A2A Demo Agent",
                     "description": "Demo JSON-RPC agent that echoes the last two words of user text.",
                     "url": "%s",
+                    "supportedInterfaces": [{
+                        "protocolBinding": "JSONRPC",
+                        "url": "%s"
+                    }],
                     "version": "0.1.0",
                     "defaultInputModes": ["text"],
                     "defaultOutputModes": ["text"],
@@ -54,6 +58,6 @@ public class RemoteA2AAgentController {
                         "tags": ["hello"]
                     }],
                     "supportsAuthenticatedExtendedCard": false
-                }""".formatted(embeddedServer.getURI().toString());
+                }""".formatted(embeddedServer.getURI().toString(), embeddedServer.getURI().toString());
     }
 }

--- a/src/test/java/io/kestra/plugin/ai/provider/DockerModelTest.java
+++ b/src/test/java/io/kestra/plugin/ai/provider/DockerModelTest.java
@@ -6,6 +6,7 @@ import java.util.Map;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
 import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.api.parallel.ResourceLock;
 
 import com.github.tomakehurst.wiremock.http.Body;
 import com.github.tomakehurst.wiremock.junit5.WireMockExtension;
@@ -28,6 +29,7 @@ import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMoc
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+@ResourceLock("kestra-h2-flyway")
 @KestraTest
 class DockerModelTest {
 

--- a/src/test/java/io/kestra/plugin/ai/tool/KestraFlowTest.java
+++ b/src/test/java/io/kestra/plugin/ai/tool/KestraFlowTest.java
@@ -8,6 +8,7 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -51,6 +52,7 @@ class KestraFlowTest {
     private final Map<String, Integer> stubStatuses = new ConcurrentHashMap<>();
     private final AtomicBoolean executionCreated = new AtomicBoolean(false);
     private final AtomicInteger requestCount = new AtomicInteger();
+    private final AtomicReference<String> lastAuthorizationHeader = new AtomicReference<>();
 
     @BeforeEach
     void setUp() throws IOException {
@@ -59,6 +61,7 @@ class KestraFlowTest {
         stubStatuses.clear();
         executionCreated.set(false);
         requestCount.set(0);
+        lastAuthorizationHeader.set(null);
         mockServer = HttpServer.create(new InetSocketAddress(0), 0);
         mockServer.createContext("/", exchange -> {
             String path = exchange.getRequestURI().getPath();
@@ -67,6 +70,7 @@ class KestraFlowTest {
             // Apache Commons FileUpload "no multipart boundary" errors
             exchange.getRequestBody().readAllBytes();
             requestCount.incrementAndGet();
+            lastAuthorizationHeader.set(exchange.getRequestHeaders().getFirst("Authorization"));
             byte[] responseBytes;
             int status;
             Integer forcedStatus = stubStatuses.get(path);
@@ -479,15 +483,34 @@ class KestraFlowTest {
             .isInstanceOf(ToolArgumentsException.class)
             .hasMessageContaining("'name'");
     }
-    /** The SDK builder defaults to Basic auth, so building a client without credentials would send `Basic base64("null:null")`. */
+    /**
+     * Opting out of the default authentication without setting any credential is how the tool declares that the
+     * Kestra API it targets requires none, so the call must go out with no `Authorization` header at all.
+     */
     @Test
-    void shouldFailWhenAutoIsDisabledWithoutCredentials() {
+    void shouldSendNoAuthorizationHeaderWhenAutoIsDisabledWithoutCredentials() throws Exception {
+        stubFlowResponses.put("/api/v1/main/flows/company.team/hello-world",
+            flowJson("company.team", "hello-world", 1, null, null));
+
         var tool = definedFlowTool("hello-world", KestraFlow.Auth.builder().auto(Property.ofValue(false)).build());
 
-        assertThatThrownBy(() -> tool.tool(runContextFactory.of(), Map.of()))
-            .isInstanceOf(IllegalArgumentException.class)
-            .hasMessageContaining("No authentication method provided");
-        assertThat(requestCount).hasValue(0);
+        tool.tool(runContextFactory.of(), Map.of());
+
+        assertThat(requestCount).hasValue(1);
+        assertThat(lastAuthorizationHeader).hasNullValue();
+    }
+
+    /** Counterpart of the test above: a credential still reaches the API, so an absent header there means something. */
+    @Test
+    void shouldSendTheApiTokenAsABearerHeader() throws Exception {
+        stubFlowResponses.put("/api/v1/main/flows/company.team/hello-world",
+            flowJson("company.team", "hello-world", 1, null, null));
+
+        var tool = definedFlowTool("hello-world", apiTokenAuth());
+
+        tool.tool(runContextFactory.of(), Map.of());
+
+        assertThat(lastAuthorizationHeader).hasValue("Bearer test-token");
     }
 
     @Test

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -7,3 +7,9 @@ kestra:
     type: local
     local:
       base-path: /tmp/unittest
+  worker:
+    controllers:
+      type: STATIC
+      static:
+        endpoints:
+          - host: localhost


### PR DESCRIPTION
- `KestraFlow` with `auth.auto: false` and no credential currently throws "No authentication method provided", so there is no way to point the tool at a Kestra API that requires no authentication. It now returns a client built with `noAuth()`, which sends no `Authorization` header. Leaving `auth.auto` on still fails fast.
- `noAuth()` only exists in kestra-api-client 2.0.0, and its Gradle variant declares JVM 25, so a Java 21 consumer cannot resolve it at all — the attribute comes from `targetCompatibility`, not from the build JDK, so building on 25 does not help. The bump therefore pulls the Kestra 2.0 / Java 25 migration in with it, and the rest of this PR is that migration. It cannot be split: the feature is unresolvable below api-client 2.0.0, which is unresolvable below Java 25, which is unresolvable below Kestra 2.0.
- Omitting the `auth` block entirely still fails fast, unchanged and still covered by `shouldFailBeforeCallingTheApiWhenNoCredentialsCanBeRetrieved`. Only the explicit `auth.auto: false` opt-out reaches the unauthenticated client.

Migration, one root cause per item:

- `kestraVersion` 1.3.17 -> 2.0.0, `targetJavaVersion` 21 -> 25, and `java-version: '25'` passed to the shared plugins workflow.
- That last one un-blocks the plugin-kestra test dependency: 0d5b7c3 reverted it from 2.0.1 to 1.11.4 only because CI compiled on JDK 21. It moves to 2.0.3.
- Kestra 2.0 splits the worker over gRPC, and the connection stub refuses to start without a worker controller endpoint, so the test `application.yml` declares a `STATIC` one.
- `DockerModelTest` was the only test class without the `kestra-h2-flyway` resource lock. Kestra 2.0 runs migrations on context startup, so concurrent classes collided on the H2 baseline schema with `object already exists: JQ_STRING`.
- The 2.0 platform BOM force-bumps langchain4j-agentic to 1.18.1-beta28, which replaces the A2A SDK with `org.a2aproject.sdk:1.1.0`. Its agent card requires `supportedInterfaces` and its JSON-RPC payloads follow the protobuf oneof mapping, so the stub server in `RemoteA2AAgentController` was updated to both.

- Before: 155 tests, 1 failure. After: 156 tests, 1 failure — the same pre-existing `ChatCompletionTest` initialization error, from the `mtls/server-keystore.p12` test resource not being in the repository.
- Supersedes #291. Everything in it other than the three version lines has already landed on `main` independently, and it targets `2.0.0-SNAPSHOT`.
