### PR TITLE
docs: lead the no-auth hint with its precondition

### DIFF
--- a/src/main/java/io/kestra/plugin/ai/tool/KestraFlow.java
+++ b/src/main/java/io/kestra/plugin/ai/tool/KestraFlow.java
@@ -319,7 +319,7 @@ public class KestraFlow extends ToolProvider {
 
     private static IllegalArgumentException noAuthentication() {
         return new IllegalArgumentException(
-            "No authentication method provided. Set the `auth` property of the tool, or configure a default one with the `kestra.tasks.sdk.authentication` properties. Set `auth.auto` to false to call a Kestra API that requires no authentication."
+            "No authentication method provided. Set the `auth` property of the tool, or configure a default one with the `kestra.tasks.sdk.authentication` properties. If this API requires no authentication, set `auth.auto` to false and leave the credentials unset."
         );
     }
 


### PR DESCRIPTION
- `KestraFlow`'s "No authentication method provided" error is thrown only when `auth.auto` is on and nothing resolved — the forgotten-or-mistyped-credentials case. Phrased as a plain instruction, the trailing hint offered that user a one-line way to make the error disappear by dropping authentication rather than by fixing their credentials.
- Leading with the condition keeps the hint for someone whose API genuinely requires none, and naming both halves of the opt-out (the flag *and* leaving credentials unset) avoids suggesting the flag alone is what does it.

Before:

> ... properties. Set `auth.auto` to false to call a Kestra API that requires no authentication.

After:

> ... properties. If this API requires no authentication, set `auth.auto` to false and leave the credentials unset.

- Same wording as kestra-io/plugin-git-lib#7, so the two stay consistent. It was pushed one commit after #422 was merged, so it missed that squash.
